### PR TITLE
extracting opencl C version from string using regex 

### DIFF
--- a/src/main/java/clearcl/ClearCLDevice.java
+++ b/src/main/java/clearcl/ClearCLDevice.java
@@ -56,11 +56,17 @@ public class ClearCLDevice extends ClearCLBase
    */
   public double getVersion()
   {
-    String lStringVersion =
+    final String[] lStringVersion =
                           getBackend().getDeviceVersion(mDevicePointer)
                                       .replace("OpenCL C", "")
-                                      .trim();
-    Double lDoubleVersion = Double.parseDouble(lStringVersion);
+                                      .trim()
+        .split("\\s+");
+
+    if(lStringVersion.length == 0){
+      return 0.;
+    }
+
+    Double lDoubleVersion = Double.parseDouble(lStringVersion[0]);
     return lDoubleVersion;
   }
 

--- a/src/test/java/clearcl/test/ClearCLDeviceTests.java
+++ b/src/test/java/clearcl/test/ClearCLDeviceTests.java
@@ -1,0 +1,66 @@
+package clearcl.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import clearcl.ClearCL;
+import clearcl.ClearCLBuffer;
+import clearcl.ClearCLContext;
+import clearcl.ClearCLDevice;
+import clearcl.ClearCLKernel;
+import clearcl.ClearCLProgram;
+import clearcl.backend.ClearCLBackendInterface;
+import clearcl.backend.ClearCLBackends;
+import clearcl.enums.BuildStatus;
+import clearcl.enums.HostAccessType;
+import clearcl.enums.KernelAccessType;
+import clearcl.exceptions.ClearCLArgumentMissingException;
+import clearcl.selector.BadDeviceSelector;
+import clearcl.selector.DeviceTypeSelector;
+import clearcl.selector.GlobalMemorySelector;
+import coremem.enums.NativeTypeEnum;
+
+import org.junit.Test;
+
+/**
+ * Basic Kernel tests
+ *
+ * @author royer
+ */
+public class ClearCLDeviceTests
+{
+
+  private void testDeviceVersion_Impl(ClearCLBackendInterface pClearCLBackendInterface) throws Exception
+  {
+    ClearCL lClearCL = new ClearCL(pClearCLBackendInterface);
+
+    ClearCLDevice lClearClDevice =
+        lClearCL.getBestDevice(DeviceTypeSelector.GPU,
+                               BadDeviceSelector.NotIntegratedIntel,
+                               GlobalMemorySelector.MAX);
+
+    final double version = lClearClDevice.getVersion();
+    System.out.println("found version "+version);
+    assertTrue(version > 0.);
+
+  }
+
+  /**
+   * Test with best backend
+   *
+   * @throws Exception
+   *           NA
+   */
+  @Test
+  public void testDeviceVersion() throws Exception
+  {
+    ClearCLBackendInterface lClearCLBackendInterface =
+                                                     ClearCLBackends.getBestBackend();
+
+    testDeviceVersion_Impl(lClearCLBackendInterface);
+  }
+
+
+
+}


### PR DESCRIPTION
to support non-standard string formats; while adding this, I saw that the clearcl API is not very precise in the sense that `ClearCLDevice.getVersion` queries the `OpenCL C` version of the given device. From a general standpoint this might be right, but `clinfo` has multiple "versions" in stock that it retrieves from the OpenCL API:
```
$ clinfo
#...
  Device Version                                  OpenCL 1.2 beignet 1.4 (git-fc5f430c)
  Driver Version                                  1.4
  Device OpenCL C Version                         OpenCL C 1.2 beignet 1.4 (git-fc5f430c)
#...
```