### PR TITLE
Port of CliJ kernels and DirectBuffer conversion code.  Not to be merged (yet)

### DIFF
--- a/src/main/java/clearcl/converters/nioConverters.java
+++ b/src/main/java/clearcl/converters/nioConverters.java
@@ -1,0 +1,142 @@
+package clearcl.converters;
+
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+import java.nio.ShortBuffer;
+
+import clearcl.ClearCLBuffer;
+import clearcl.ClearCLContext;
+import clearcl.ClearCLImage;
+import clearcl.enums.HostAccessType;
+import clearcl.enums.ImageChannelDataType;
+import clearcl.enums.ImageChannelOrder;
+import clearcl.enums.KernelAccessType;
+import clearcl.enums.MemAllocMode;
+import clearcl.interfaces.ClearCLImageInterface;
+import coremem.enums.NativeTypeEnum;
+
+/**
+ *
+ * @author nico
+ */
+public class nioConverters
+{
+
+  /**
+   * convertNioTiClearCL
+   *
+   * Author: @nicost 6 2019
+   *
+   * @param context
+   *          ClearCLContext instance - the thing that knows about the GPU
+   * @param source
+   *          Java Direct Buffer containing intensity (pixel) data
+   * @param dimensions
+   *          Dimensions of the image. Should be 2D or 3D (higher?) Mismatch
+   *          with the input data may be disastrous
+   * @return ClearCLBuffer containing a copy of the input data
+   */
+  public static ClearCLBuffer convertNioTiClearCLBuffer(ClearCLContext context,
+                                                        Buffer source,
+                                                        long[] dimensions)
+  {
+    ClearCLBuffer target;
+    NativeTypeEnum type = null;
+    if (source instanceof ByteBuffer)
+    {
+      type = NativeTypeEnum.UnsignedByte;
+    }
+    else if (source instanceof ShortBuffer)
+    {
+      type = NativeTypeEnum.UnsignedShort;
+    }
+    else if (source instanceof FloatBuffer)
+    {
+      type = NativeTypeEnum.Float;
+    } // Todo: other types, exception when type not found
+    target = context.createBuffer(MemAllocMode.Best,
+                                  HostAccessType.ReadWrite,
+                                  KernelAccessType.ReadWrite,
+                                  1L,
+                                  type,
+                                  dimensions);
+    target.readFrom(source, true);
+
+    return target;
+  }
+
+  public static ClearCLImage convertNioTiClearCLImage(ClearCLContext context,
+                                                      Buffer source,
+                                                      long[] dimensions)
+  {
+    ClearCLImage target;
+    ImageChannelDataType type = null;
+    if (source instanceof ByteBuffer)
+    {
+      type = ImageChannelDataType.UnsignedInt8;
+    }
+    else if (source instanceof ShortBuffer)
+    {
+      type = ImageChannelDataType.UnsignedInt16;
+    }
+    else if (source instanceof FloatBuffer)
+    {
+      type = ImageChannelDataType.Float;
+    } // Todo: other types, exception when type not found
+    target =
+           context.createImage(HostAccessType.ReadWrite,
+                               KernelAccessType.ReadWrite,
+                               ImageChannelOrder.R,
+                               type,
+                               dimensions);
+    target.readFrom(source, true);
+
+    return target;
+  }
+
+  /**
+   * Copies Intensity data from ClearCLBuffer to Java Direct Buffer Input is
+   * either ClearCLBuffer or ClearCLImage Caller will also need dimensions:
+   * source.getDimensions()
+   * 
+   * @param source
+   *          ClearCLBuffer to be convert to Java direct Buffer
+   * @return Java Direct Buffer
+   */
+  public static Buffer convertClearCLBufferToNio(ClearCLImageInterface source)
+  {
+    Buffer buffer = null;
+    if (null != source.getNativeType())
+      switch (source.getNativeType())
+      {
+      case UnsignedByte:
+        buffer =
+               ByteBuffer.allocate((int) (source.getSizeInBytes()
+                                          / source.getNativeType()
+                                                  .getSizeInBytes()));
+        source.writeTo(buffer, true);
+        break;
+      case UnsignedShort:
+        buffer =
+               ShortBuffer.allocate((int) (source.getSizeInBytes()
+                                           / source.getNativeType()
+                                                   .getSizeInBytes()));
+        source.writeTo(buffer, true);
+        break;
+      case Float:
+        buffer =
+               FloatBuffer.allocate((int) (source.getSizeInBytes()
+                                           / source.getNativeType()
+                                                   .getSizeInBytes()));
+        source.writeTo(buffer, true);
+        break;
+      default:
+        // Todo: other types, exception when type not found
+        break;
+      }
+
+    return buffer;
+  }
+
+}

--- a/src/main/java/clearcl/ocllib/kernels/affineTransforms.cl
+++ b/src/main/java/clearcl/ocllib/kernels/affineTransforms.cl
@@ -1,0 +1,91 @@
+// adapted from: https://github.com/maweigert/gputools/blob/master/gputools/transforms/kernels/transformations.cl
+//
+// Copyright (c) 2016, Martin Weigert
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of gputools nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+#ifndef SAMPLER_FILTER
+#define SAMPLER_FILTER CLK_FILTER_LINEAR
+#endif
+
+#ifndef SAMPLER_ADDRESS
+#define SAMPLER_ADDRESS CLK_ADDRESS_CLAMP
+#endif
+
+__kernel void affine(DTYPE_IMAGE_IN_3D input,
+	      			 DTYPE_IMAGE_OUT_3D output,
+				 __constant float * mat)
+{
+
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_TRUE|
+      SAMPLER_ADDRESS |	SAMPLER_FILTER;
+
+  uint i = get_global_id(0);
+  uint j = get_global_id(1);
+  uint k = get_global_id(2);
+
+  uint Nx = get_global_size(0);
+  uint Ny = get_global_size(1);
+  uint Nz = get_global_size(2);
+
+  //float x = (mat[0]*i+mat[1]*j+mat[2]*k+mat[3]);
+  //float y = (mat[4]*i+mat[5]*j+mat[6]*k+mat[7]);
+  //float z = (mat[8]*i+mat[9]*j+mat[10]*k+mat[11]);
+  ////ensure correct sampling, see opencl 1.2 specification pg. 329
+  //x += 0.5f;
+  //y += 0.5f;
+  //z += 0.5f;
+
+  float x = i+0.5f;
+  float y = j+0.5f;
+  float z = k+0.5f;
+
+  float z2 = (mat[8]*x+mat[9]*y+mat[10]*z+mat[11]);
+  float y2 = (mat[4]*x+mat[5]*y+mat[6]*z+mat[7]);
+  float x2 = (mat[0]*x+mat[1]*y+mat[2]*z+mat[3]);
+
+
+  //int4 coord_norm = (int4)(x2 * GET_IMAGE_WIDTH(input) / GET_IMAGE_WIDTH(output),y2 * GET_IMAGE_HEIGHT(input) / GET_IMAGE_HEIGHT(output), z2  * GET_IMAGE_DEPTH(input) / GET_IMAGE_DEPTH(output),0.f);
+  int4 coord_norm = (int4)(x2,y2, z2,0.f);
+
+
+
+  float pix = 0;
+  if (x2 >= 0 && y2 >= 0 && z2 >= 0 &&
+      x2 < GET_IMAGE_WIDTH(input) && y2 < GET_IMAGE_HEIGHT(input) && z2 < GET_IMAGE_DEPTH(input)
+  ) {
+    pix = (float)(READ_IMAGE_3D(input, sampler, coord_norm).x);
+  }
+
+  int4 pos = (int4){i, j, k,0};
+
+  WRITE_IMAGE_3D(output, pos, (DTYPE_OUT) pix);
+
+
+}

--- a/src/main/java/clearcl/ocllib/kernels/affineTransforms_interpolate.cl
+++ b/src/main/java/clearcl/ocllib/kernels/affineTransforms_interpolate.cl
@@ -1,0 +1,82 @@
+// adapted from: https://github.com/maweigert/gputools/blob/master/gputools/transforms/kernels/transformations.cl
+//
+// Copyright (c) 2016, Martin Weigert
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of gputools nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+#ifndef SAMPLER_FILTER
+#define SAMPLER_FILTER CLK_FILTER_LINEAR
+#endif
+
+#ifndef SAMPLER_ADDRESS
+#define SAMPLER_ADDRESS CLK_ADDRESS_CLAMP
+#endif
+
+__kernel void affine_interpolate(DTYPE_IMAGE_IN_3D input,
+	      			 DTYPE_IMAGE_OUT_3D output,
+				 __constant float * mat)
+{
+
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_TRUE|
+      SAMPLER_ADDRESS |	SAMPLER_FILTER;
+
+  uint i = get_global_id(0);
+  uint j = get_global_id(1);
+  uint k = get_global_id(2);
+
+  uint Nx = GET_IMAGE_WIDTH(input);
+  uint Ny = GET_IMAGE_HEIGHT(input);
+  uint Nz = GET_IMAGE_DEPTH(input);
+
+  //float x = (mat[0]*i+mat[1]*j+mat[2]*k+mat[3]);
+  //float y = (mat[4]*i+mat[5]*j+mat[6]*k+mat[7]);
+  //float z = (mat[8]*i+mat[9]*j+mat[10]*k+mat[11]);
+  ////ensure correct sampling, see opencl 1.2 specification pg. 329
+  //x += 0.5f;
+  //y += 0.5f;
+  //z += 0.5f;
+
+  float x = i+0.5f;
+  float y = j+0.5f;
+  float z = k+0.5f;
+
+  float z2 = (mat[8]*x+mat[9]*y+mat[10]*z+mat[11]);
+  float y2 = (mat[4]*x+mat[5]*y+mat[6]*z+mat[7]);
+  float x2 = (mat[0]*x+mat[1]*y+mat[2]*z+mat[3]);
+
+  //float4 coord_norm = (float4)(x2 * GET_IMAGE_WIDTH(input) / GET_IMAGE_WIDTH(output) / Nx,y2 * GET_IMAGE_HEIGHT(input) / GET_IMAGE_HEIGHT(output) / Ny, z2  * GET_IMAGE_DEPTH(input) / GET_IMAGE_DEPTH(output) / Nz,0.f);
+  float4 coord_norm = (float4)(x2/Nx,y2/Ny,z2/Nz,0.f);
+
+  float pix = (float)(READ_IMAGE_3D(input, sampler, coord_norm).x);
+  int4 pos = (int4){i, j, k,0};
+
+  WRITE_IMAGE_3D(output, pos, (DTYPE_OUT) pix);
+
+
+}

--- a/src/main/java/clearcl/ocllib/kernels/binaryCounting.cl
+++ b/src/main/java/clearcl/ocllib/kernels/binaryCounting.cl
@@ -1,0 +1,123 @@
+__constant sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+__kernel void count_nonzero_slicewise_image3d
+(
+  DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src,
+  const int Nx, const int Ny
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4){i,j,k,0};
+
+    const int4   e = (int4)  {(Nx-1)/2, (Ny-1)/2, 0, 0 };
+
+    float aSquared = e.x * e.x;
+    float bSquared = e.y * e.y;
+
+    DTYPE_OUT sum = 0;
+    int count = 0;
+
+    for (int x = -e.x; x <= e.x; x++) {
+        float xSquared = x * x;
+        for (int y = -e.y; y <= e.y; y++) {
+            float ySquared = y * y;
+            if (xSquared / aSquared + ySquared / bSquared <= 1.0) {
+                DTYPE_OUT value = (DTYPE_OUT)READ_IMAGE_3D(src,sampler,coord+((int4){x,y,k,0})).x;
+                if (value != 0) {
+                    count++;
+                }
+            }
+        }
+    }
+
+  DTYPE_OUT res = count;
+  WRITE_IMAGE_3D(dst, coord, res);
+}
+
+
+__kernel void count_nonzero_image2d
+(
+  DTYPE_IMAGE_OUT_2D dst, DTYPE_IMAGE_IN_2D src,
+  const int Nx, const int Ny
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1);
+  const int2 coord = (int2){i,j};
+
+    const int4   e = (int4)  {(Nx-1)/2, (Ny-1)/2, 0, 0 };
+    int count = 0;
+    float sum = 0;
+
+    float aSquared = e.x * e.x;
+    float bSquared = e.y * e.y;
+
+  for (int x = -e.x; x <= e.x; x++) {
+      float xSquared = x * x;
+      for (int y = -e.y; y <= e.y; y++) {
+          float ySquared = y * y;
+          if (xSquared / aSquared + ySquared / bSquared <= 1.0) {
+              DTYPE_OUT value = (DTYPE_OUT)READ_IMAGE_2D(src,sampler,coord+((int2){x,y})).x;
+              if (value != 0) {
+                  count++;
+              }
+          }
+      }
+  }
+
+  DTYPE_OUT res = count;
+  WRITE_IMAGE_2D(dst, coord, res);
+}
+
+__kernel void count_nonzero_image3d
+(
+  DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src,
+  const int Nx, const int Ny, const int Nz
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4){i,j,k,0};
+
+    const int4   e = (int4)  {(Nx-1)/2, (Ny-1)/2, (Nz-1)/2, 0 };
+    int count = 0;
+    float sum = 0;
+
+    float aSquared = e.x * e.x;
+    float bSquared = e.y * e.y;
+    float cSquared = e.z * e.z;
+
+    for (int x = -e.x; x <= e.x; x++) {
+        float xSquared = x * x;
+        for (int y = -e.y; y <= e.y; y++) {
+            float ySquared = y * y;
+            for (int z = -e.z; z <= e.z; z++) {
+                float zSquared = z * z;
+                if (xSquared / aSquared + ySquared / bSquared + zSquared / cSquared <= 1.0) {
+
+                    int x1 = coord.x + x;
+                    int x2 = coord.y + y;
+                    int x3 = coord.z + z;
+                    const int4 pos = (int4){x1,x2,x3,0};
+                    float value_res = (float)READ_IMAGE_3D(src,sampler,pos).x;
+                    if (value_res != 0) {
+                    count++;
+                    }
+                }
+            }
+        }
+    }
+
+
+  DTYPE_OUT res = count;
+  WRITE_IMAGE_3D(dst, coord, res);
+}
+
+
+
+
+
+
+
+
+
+
+

--- a/src/main/java/clearcl/ocllib/kernels/binaryProcessing.cl
+++ b/src/main/java/clearcl/ocllib/kernels/binaryProcessing.cl
@@ -1,0 +1,520 @@
+__constant sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+__kernel void binary_or_2d(DTYPE_IMAGE_IN_2D  src1,
+                           DTYPE_IMAGE_IN_2D  src2,
+                           DTYPE_IMAGE_OUT_2D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int2 pos = (int2){x,y};
+
+  DTYPE_OUT value1 = READ_IMAGE_2D(src1, sampler, pos).x;
+  DTYPE_OUT value2 = READ_IMAGE_2D(src2, sampler, pos).x;
+  if ( value1 > 0 || value2 > 0 ) {
+    value1 = 1;
+  } else {
+    value1 = 0;
+  }
+  WRITE_IMAGE_2D (dst, pos, value1);
+}
+
+__kernel void binary_and_2d(DTYPE_IMAGE_IN_2D  src1,
+                           DTYPE_IMAGE_IN_2D  src2,
+                           DTYPE_IMAGE_OUT_2D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int2 pos = (int2){x,y};
+
+  DTYPE_OUT value1 = READ_IMAGE_2D(src1, sampler, pos).x;
+  DTYPE_OUT value2 = READ_IMAGE_2D(src2, sampler, pos).x;
+  if ( value1 > 0 && value2 > 0 ) {
+    value1 = 1;
+  } else {
+    value1 = 0;
+  }
+  WRITE_IMAGE_2D (dst, pos, value1);
+}
+
+__kernel void binary_xor_2d(DTYPE_IMAGE_IN_2D  src1,
+                           DTYPE_IMAGE_IN_2D  src2,
+                           DTYPE_IMAGE_OUT_2D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int2 pos = (int2){x,y};
+
+  DTYPE_OUT value1 = READ_IMAGE_2D(src1, sampler, pos).x;
+  DTYPE_OUT value2 = READ_IMAGE_2D(src2, sampler, pos).x;
+  if ( (value1 > 0 && value2 == 0) || (value1 == 0 && value2 > 0)) {
+    value1 = 1;
+  } else {
+    value1 = 0;
+  }
+  WRITE_IMAGE_2D (dst, pos, value1);
+}
+
+__kernel void binary_not_2d(DTYPE_IMAGE_IN_2D  src1,
+                           DTYPE_IMAGE_OUT_2D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int2 pos = (int2){x,y};
+
+  DTYPE_OUT value1 = READ_IMAGE_2D(src1, sampler, pos).x;
+  if ( value1 > 0) {
+    value1 = 0;
+  } else {
+    value1 = 1;
+  }
+  WRITE_IMAGE_2D (dst, pos, value1);
+}
+
+__kernel void binary_or_3d(DTYPE_IMAGE_IN_3D  src1,
+                           DTYPE_IMAGE_IN_3D  src2,
+                           DTYPE_IMAGE_OUT_3D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  DTYPE_OUT value1 = READ_IMAGE_3D(src1, sampler, pos).x;
+  DTYPE_OUT value2 = READ_IMAGE_3D(src2, sampler, pos).x;
+  if ( value1 > 0 || value2 > 0 ) {
+    value1 = 1;
+  } else {
+    value1 = 0;
+  }
+  WRITE_IMAGE_3D (dst, pos, value1);
+}
+
+__kernel void binary_and_3d(DTYPE_IMAGE_IN_3D  src1,
+                           DTYPE_IMAGE_IN_3D  src2,
+                           DTYPE_IMAGE_OUT_3D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  DTYPE_OUT value1 = READ_IMAGE_3D(src1, sampler, pos).x;
+  DTYPE_OUT value2 = READ_IMAGE_3D(src2, sampler, pos).x;
+  if ( value1 > 0 && value2 > 0 ) {
+    value1 = 1;
+  } else {
+    value1 = 0;
+  }
+  WRITE_IMAGE_3D (dst, pos, value1);
+}
+
+__kernel void binary_xor_3d(DTYPE_IMAGE_IN_3D  src1,
+                           DTYPE_IMAGE_IN_3D  src2,
+                           DTYPE_IMAGE_OUT_3D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  DTYPE_OUT value1 = READ_IMAGE_3D(src1, sampler, pos).x;
+  DTYPE_OUT value2 = READ_IMAGE_3D(src2, sampler, pos).x;
+  if ( (value1 > 0 && value2 == 0) || (value1 == 0 && value2 > 0)) {
+    value1 = 1;
+  } else {
+    value1 = 0;
+  }
+  WRITE_IMAGE_3D (dst, pos, value1);
+}
+
+__kernel void binary_not_3d(DTYPE_IMAGE_IN_3D  src1,
+                           DTYPE_IMAGE_OUT_3D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  DTYPE_OUT value1 = READ_IMAGE_3D(src1, sampler, pos).x;
+  if ( value1 > 0) {
+    value1 = 0;
+  } else {
+    value1 = 1;
+  }
+  WRITE_IMAGE_3D (dst, pos, value1);
+}
+
+__kernel void erode_box_neighborhood_3d(DTYPE_IMAGE_IN_3D  src,
+                          DTYPE_IMAGE_OUT_3D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  DTYPE_OUT value = READ_IMAGE_3D(src, sampler, pos).x;
+  if (value > 0) {
+    for (int x = -1; x <= 1; x++) {
+      for (int y = -1; y <= 1; y++) {
+        for (int z = -1; z <= 1; z++) {
+          value = READ_IMAGE_3D(src, sampler, (pos + (int4){x, y, z, 0})).x;
+          if (value == 0) {
+            break;
+          }
+        }
+        if (value == 0) {
+          break;
+        }
+      }
+      if (value == 0) {
+        break;
+      }
+    }
+  }
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+__kernel void erode_box_neighborhood_slice_by_slice(DTYPE_IMAGE_IN_3D  src,
+                          DTYPE_IMAGE_OUT_3D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  DTYPE_OUT value = READ_IMAGE_3D(src, sampler, pos).x;
+  if (value > 0) {
+    for (int x = -1; x <= 1; x++) {
+      for (int y = -1; y <= 1; y++) {
+        value = READ_IMAGE_3D(src, sampler, (pos + (int4){x, y, z, 0})).x;
+        if (value == 0) {
+          break;
+        }
+      }
+      if (value == 0) {
+        break;
+      }
+    }
+  }
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+
+__kernel void erode_box_neighborhood_2d(DTYPE_IMAGE_IN_2D  src,
+                          DTYPE_IMAGE_OUT_2D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int2 pos = (int2){x,y};
+
+  DTYPE_OUT value = READ_IMAGE_2D(src, sampler, pos).x;
+  if (value > 0) {
+    for (int x = -1; x <= 1; x++) {
+      for (int y = -1; y <= 1; y++) {
+        value = READ_IMAGE_2D(src, sampler, (pos + (int2){x, y})).x;
+        if (value == 0) {
+          break;
+        }
+      }
+      if (value == 0) {
+        break;
+      }
+    }
+  }
+
+  WRITE_IMAGE_2D (dst, pos, value);
+}
+
+__kernel void erode_diamond_neighborhood_3d(DTYPE_IMAGE_IN_3D  src,
+                          DTYPE_IMAGE_OUT_3D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  DTYPE_OUT value = READ_IMAGE_3D(src, sampler, pos).x;
+  if (value > 0) {
+    value = READ_IMAGE_3D(src, sampler, (pos + (int4){1, 0, 0, 0})).x;
+    if (value > 0) {
+      value = READ_IMAGE_3D(src, sampler, (pos + (int4){-1, 0, 0, 0})).x;
+      if (value > 0) {
+        value = READ_IMAGE_3D(src, sampler, (pos + (int4){0, 1, 0, 0})).x;
+        if (value > 0) {
+          value = READ_IMAGE_3D(src, sampler, (pos + (int4){0, -1, 0, 0})).x;
+          if (value > 0) {
+            value = READ_IMAGE_3D(src, sampler, (pos + (int4){0, 0, 1, 0})).x;
+            if (value > 0) {
+              value = READ_IMAGE_3D(src, sampler, (pos + (int4){0, 0, -1, 0})).x;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+__kernel void erode_diamond_neighborhood_slice_by_slice(DTYPE_IMAGE_IN_3D  src,
+                          DTYPE_IMAGE_OUT_3D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  DTYPE_OUT value = READ_IMAGE_3D(src, sampler, pos).x;
+  if (value > 0) {
+    value = READ_IMAGE_3D(src, sampler, (pos + (int4){1, 0, 0, 0})).x;
+    if (value > 0) {
+      value = READ_IMAGE_3D(src, sampler, (pos + (int4){-1, 0, 0, 0})).x;
+      if (value > 0) {
+        value = READ_IMAGE_3D(src, sampler, (pos + (int4){0, 1, 0, 0})).x;
+        if (value > 0) {
+          value = READ_IMAGE_3D(src, sampler, (pos + (int4){0, -1, 0, 0})).x;
+        }
+      }
+    }
+  }
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+
+
+__kernel void erode_diamond_neighborhood_2d(DTYPE_IMAGE_IN_2D  src,
+                          DTYPE_IMAGE_OUT_2D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int2 pos = (int2){x,y};
+
+  DTYPE_OUT value = READ_IMAGE_2D(src, sampler, pos).x;
+  if (value > 0) {
+    value = READ_IMAGE_2D(src, sampler, (pos + (int2){1, 0})).x;
+    if (value > 0) {
+      value = READ_IMAGE_2D(src, sampler, (pos + (int2){-1, 0})).x;
+      if (value > 0) {
+        value = READ_IMAGE_2D(src, sampler, (pos + (int2){0, 1})).x;
+        if (value > 0) {
+          value = READ_IMAGE_2D(src, sampler, (pos + (int2){0, -1})).x;
+        }
+      }
+    }
+  }
+
+  WRITE_IMAGE_2D (dst, pos, value);
+}
+
+__kernel void dilate_box_neighborhood_3d(DTYPE_IMAGE_IN_3D  src,
+                          DTYPE_IMAGE_OUT_3D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  DTYPE_OUT value = READ_IMAGE_3D(src, sampler, pos).x;
+  if (value < 1) {
+    for (int x = -1; x <= 1; x++) {
+      for (int y = -1; y <= 1; y++) {
+        for (int z = -1; z <= 1; z++) {
+          value = READ_IMAGE_3D(src, sampler, (pos + (int4){x, y, z, 0})).x;
+          if (value > 0) {
+            break;
+          }
+        }
+        if (value > 0) {
+          break;
+        }
+      }
+      if (value > 0) {
+        break;
+      }
+    }
+  }
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+__kernel void dilate_box_neighborhood_slice_by_slice(DTYPE_IMAGE_IN_3D  src,
+                          DTYPE_IMAGE_OUT_3D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  DTYPE_OUT value = READ_IMAGE_3D(src, sampler, pos).x;
+  if (value < 1) {
+    for (int x = -1; x <= 1; x++) {
+      for (int y = -1; y <= 1; y++) {
+        value = READ_IMAGE_3D(src, sampler, (pos + (int4){x, y, z, 0})).x;
+        if (value > 0) {
+          break;
+        }
+      }
+      if (value > 0) {
+        break;
+      }
+    }
+  }
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+__kernel void dilate_box_neighborhood_2d(DTYPE_IMAGE_IN_2D  src,
+                          DTYPE_IMAGE_OUT_2D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int2 pos = (int2){x,y};
+
+  DTYPE_OUT value = READ_IMAGE_2D(src, sampler, pos).x;
+  if (value < 1) {
+    for (int x = -1; x <= 1; x++) {
+      for (int y = -1; y <= 1; y++) {
+        value = READ_IMAGE_2D(src, sampler, (pos + (int2){x, y})).x;
+        if (value > 0) {
+          break;
+        }
+      }
+      if (value > 0) {
+        break;
+      }
+    }
+  }
+
+  WRITE_IMAGE_2D (dst, pos, value);
+}
+
+__kernel void dilate_diamond_neighborhood_3d(DTYPE_IMAGE_IN_3D  src,
+                          DTYPE_IMAGE_OUT_3D dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  DTYPE_OUT value = READ_IMAGE_3D(src, sampler, pos).x;
+  if (value < 1) {
+
+    value = READ_IMAGE_3D(src, sampler, (pos + (int4){1, 0, 0, 0})).x;
+    if (value < 1) {
+      value = READ_IMAGE_3D(src, sampler, (pos + (int4){-1, 0, 0, 0})).x;
+      if (value < 1) {
+        value = READ_IMAGE_3D(src, sampler, (pos + (int4){0, 1, 0, 0})).x;
+        if (value < 1) {
+          value = READ_IMAGE_3D(src, sampler, (pos + (int4){0, -1, 0, 0})).x;
+          if (value < 1) {
+            value = READ_IMAGE_3D(src, sampler, (pos + (int4){0, 0, 1, 0})).x;
+            if (value < 1) {
+              value = READ_IMAGE_3D(src, sampler, (pos + (int4){0, 0, -1, 0})).x;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+__kernel void dilate_diamond_neighborhood_slice_by_slice(DTYPE_IMAGE_IN_3D  src,
+                          DTYPE_IMAGE_OUT_3D dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  DTYPE_OUT value = READ_IMAGE_3D(src, sampler, pos).x;
+  if (value < 1) {
+
+    value = READ_IMAGE_3D(src, sampler, (pos + (int4){1, 0, 0, 0})).x;
+    if (value < 1) {
+      value = READ_IMAGE_3D(src, sampler, (pos + (int4){-1, 0, 0, 0})).x;
+      if (value < 1) {
+        value = READ_IMAGE_3D(src, sampler, (pos + (int4){0, 1, 0, 0})).x;
+        if (value < 1) {
+          value = READ_IMAGE_3D(src, sampler, (pos + (int4){0, -1, 0, 0})).x;
+          if (value < 1) {
+            value = READ_IMAGE_3D(src, sampler, (pos + (int4){0, 0, 1, 0})).x;
+            if (value < 1) {
+              value = READ_IMAGE_3D(src, sampler, (pos + (int4){0, 0, -1, 0})).x;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+__kernel void dilate_diamond_neighborhood_2d(DTYPE_IMAGE_IN_2D  src,
+                          DTYPE_IMAGE_OUT_2D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int2 pos = (int2){x,y};
+
+  DTYPE_OUT value = READ_IMAGE_2D(src, sampler, pos).x;
+  if (value < 1) {
+    value = READ_IMAGE_2D(src, sampler, (pos + (int2){1, 0})).x;
+    if (value < 1) {
+      value = READ_IMAGE_2D(src, sampler, (pos + (int2){-1, 0})).x;
+      if (value < 1) {
+        value = READ_IMAGE_2D(src, sampler, (pos + (int2){0, 1})).x;
+        if (value < 1) {
+          value = READ_IMAGE_2D(src, sampler, (pos + (int2){0, -1})).x;
+        }
+      }
+    }
+  }
+
+  WRITE_IMAGE_2D (dst, pos, value);
+}

--- a/src/main/java/clearcl/ocllib/kernels/blur.cl
+++ b/src/main/java/clearcl/ocllib/kernels/blur.cl
@@ -1,0 +1,186 @@
+// Adapted from Uwe Schmidt, https://github.com/ClearControl/FastFuse/blob/master/src/fastfuse/tasks/kernels/blur.cl
+//
+
+__constant sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+
+__kernel void gaussian_blur_image3d
+(
+  DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src,
+  const int Nx, const int Ny, const int Nz,
+  const float sx, const float sy, const float sz
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4)(i,j,k,0);
+
+  // centers
+  const int4   c = (int4)  ( (Nx-1)/2, (Ny-1)/2, (Nz-1)/2, 0 );
+  // normalizations
+  const float4 n = (float4)( -2*sx*sx, -2*sy*sy, -2*sz*sz, 0 );
+
+  float res = 0, hsum = 0;
+
+  for (int x = -c.x; x <= c.x; x++) {
+    const float wx = (x*x) / n.x;
+    for (int y = -c.y; y <= c.y; y++) {
+      const float wy = (y*y) / n.y;
+      for (int z = -c.z; z <= c.z; z++) {
+        const float wz = (z*z) / n.z;
+        const float h = exp(wx + wy + wz);
+        res += h * (float)READ_IMAGE_3D(src,sampler,coord+(int4)(x,y,z,0)).x;
+        hsum += h;
+      }
+    }
+  }
+
+  res /= hsum;
+  WRITE_IMAGE_3D(dst,coord,(DTYPE_OUT)res);
+}
+
+
+__kernel void gaussian_blur_slicewise_image3d
+(
+  DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src,
+  const int Nx, const int Ny,
+  const float sx, const float sy
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4)(i,j,k,0);
+
+  // centers
+  const int4   c = (int4)  ( (Nx-1)/2, (Ny-1)/2, 0, 0 );
+  // normalizations
+  const float4 n = (float4)( -2*sx*sx, -2*sy*sy, 0, 0 );
+
+  float res = 0, hsum = 0;
+
+  for (int x = -c.x; x <= c.x; x++) {
+    const float wx = (x*x) / n.x;
+    for (int y = -c.y; y <= c.y; y++) {
+      const float wy = (y*y) / n.y;
+      const float h = exp(wx + wy);
+      res += h * (float)READ_IMAGE_3D(src,sampler,coord+(int4)(x,y,0,0)).x;
+      hsum += h;
+    }
+  }
+
+  res /= hsum;
+  WRITE_IMAGE_3D(dst,coord,(DTYPE_OUT)res);
+}
+
+__kernel void gaussian_blur_image2d
+(
+  DTYPE_IMAGE_OUT_2D dst, DTYPE_IMAGE_IN_2D src,
+  const int Nx, const int Ny,
+  const float sx, const float sy
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1);
+  const int2 coord = (int2)(i,j);
+
+  // centers
+  const int2   c = (int2)  ( (Nx-1)/2, (Ny-1)/2 );
+  // normalizations
+  const float2 n = (float2)( -2*sx*sx, -2*sy*sy);
+
+  float res = 0, hsum = 0;
+
+  for (int x = -c.x; x <= c.x; x++) {
+    const float wx = (x*x) / n.x;
+    for (int y = -c.y; y <= c.y; y++) {
+      const float wy = (y*y) / n.y;
+      const float h = exp(wx + wy);
+      res += h * (float)READ_IMAGE_2D(src,sampler,coord+(int2)(x,y)).x;
+      hsum += h;
+    }
+  }
+
+  res /= hsum;
+  WRITE_IMAGE_2D(dst,coord,(DTYPE_OUT)res);
+}
+
+__kernel void gaussian_blur_image2d_ij
+(
+  DTYPE_IMAGE_OUT_2D dst, DTYPE_IMAGE_IN_2D src,
+  const int Nx, const int Ny,
+  const float sx, const float sy
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1);
+  const int2 coord = (int2)(i,j);
+
+  // centers
+  const int2   c = (int2)  ( (Nx-1)/2, (Ny-1)/2 );
+  // normalizations
+  const float2 n = (float2)( -2*sx*sx, -2*sy*sy);
+
+  float res = 0, hsum = 0;
+
+  for (int x = -c.x; x <= c.x; x++) {
+    const float wx = (x*x) / n.x;
+    for (int y = -c.y; y <= c.y; y++) {
+      const float wy = (y*y) / n.y;
+      const float h = exp(wx + wy);
+      res += h * (float)READ_IMAGE_2D(src,sampler,coord+(int2)(x,y)).x;
+      hsum += h;
+    }
+  }
+
+  res /= hsum;
+  WRITE_IMAGE_2D(dst,coord,(DTYPE_OUT)res);
+}
+
+__kernel void gaussian_blur_sep_image3d
+(
+  DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src,
+  const int dim, const int N, const float s
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4)(i,j,k,0);
+  const int4 dir   = (int4)(dim==0,dim==1,dim==2,0);
+
+  // center
+  const int   c = (N-1)/2;
+  // normalization
+  const float n = -2*s*s;
+
+  float res = 0, hsum = 0;
+  for (int v = -c; v <= c; v++) {
+    const float h = exp((v*v)/n);
+    res += h * (float)READ_IMAGE_3D(src,sampler,coord+v*dir).x;
+    hsum += h;
+  }
+  res /= hsum;
+  WRITE_IMAGE_3D(dst,coord,(DTYPE_OUT)res);
+}
+
+
+__kernel void gaussian_blur_sep_image2d
+(
+  DTYPE_IMAGE_OUT_2D dst, DTYPE_IMAGE_IN_2D src,
+  const int dim, const int N, const float s
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1);
+  const int2 coord = (int2)(i,j);
+  const int2 dir   = (int2)(dim==0,dim==1);
+
+  // center
+  const int   c = (N-1)/2;
+  // normalization
+  const float n = -2*s*s;
+
+  float res = 0, hsum = 0;
+  for (int v = -c; v <= c; v++) {
+    const float h = exp((v*v)/n);
+    res += h * (float)READ_IMAGE_2D(src,sampler,coord+v*dir).x;
+    hsum += h;
+  }
+  res /= hsum;
+  WRITE_IMAGE_2D(dst,coord,(DTYPE_OUT)(res));
+}
+
+

--- a/src/main/java/clearcl/ocllib/kernels/cross_correlation.cl
+++ b/src/main/java/clearcl/ocllib/kernels/cross_correlation.cl
@@ -1,0 +1,38 @@
+
+__kernel void cross_correlation_3d(DTYPE_IMAGE_IN_3D src1,
+                                    DTYPE_IMAGE_IN_3D mean_src1,
+                                    DTYPE_IMAGE_IN_3D src2,
+                                    DTYPE_IMAGE_IN_3D mean_src2,
+                                    DTYPE_IMAGE_OUT_3D dst,
+                                    int radius,
+                                    int i,
+                                    int dimension)
+{
+
+    const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+    int4 pos = {get_global_id(0), get_global_id(1), get_global_id(2), 0};
+    int4 deltaPos = {get_global_id(0), get_global_id(1), get_global_id(2), 0};
+
+
+    float sum1 = 0;
+    float sum2 = 0;
+    float sum3 = 0;
+    for(int k = -radius; k < radius + 1; k++)
+    {
+        deltaPos[dimension] = get_global_id(dimension) + k;
+        float Ia = READ_IMAGE_3D(src1, sampler, deltaPos).x;
+        float meanIa = READ_IMAGE_3D(mean_src1, sampler, deltaPos).x;
+        deltaPos[dimension] = get_global_id(dimension) + k + i;
+        float Ib = READ_IMAGE_3D(src2, sampler, deltaPos).x;
+        float meanIb = READ_IMAGE_3D(mean_src2, sampler, deltaPos).x;
+
+        sum1 = sum1 + (Ia - meanIa) * (Ib - meanIb);
+        sum2 = sum2 + pow((float)(Ia - meanIa), (float)2.0);
+        sum3 = sum3 + pow((float)(Ib - meanIb), (float)2.0);
+    }
+
+    float result = sum1 / pow((float)(sum2 * sum3), (float)0.5);
+
+    WRITE_IMAGE_3D(dst, pos, (DTYPE_OUT) result);
+}

--- a/src/main/java/clearcl/ocllib/kernels/deform.cl
+++ b/src/main/java/clearcl/ocllib/kernels/deform.cl
@@ -1,0 +1,89 @@
+
+#ifndef SAMPLER_FILTER
+#define SAMPLER_FILTER CLK_FILTER_LINEAR
+#endif
+
+#ifndef SAMPLER_ADDRESS
+#define SAMPLER_ADDRESS CLK_ADDRESS_CLAMP
+#endif
+
+__kernel void deform_3d(DTYPE_IMAGE_IN_3D src,
+                        DTYPE_IMAGE_IN_3D vectorX,
+                        DTYPE_IMAGE_IN_3D vectorY,
+                        DTYPE_IMAGE_IN_3D vectorZ,
+	      			 DTYPE_IMAGE_OUT_3D dst)
+{
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_TRUE|
+      SAMPLER_ADDRESS |	SAMPLER_FILTER;
+
+  uint i = get_global_id(0);
+  uint j = get_global_id(1);
+  uint k = get_global_id(2);
+
+  uint Nx = get_global_size(0);
+  uint Ny = get_global_size(1);
+  uint Nz = get_global_size(2);
+
+  float x = i+0.5f;
+  float y = j+0.5f;
+  float z = k+0.5f;
+
+  int4 pos = (int4){i, j, k,0};
+
+  float x2 = x + (float)(READ_IMAGE_3D(vectorX, sampler, pos).x);
+  float y2 = y + (float)(READ_IMAGE_3D(vectorY, sampler, pos).x);
+  float z2 = z + (float)(READ_IMAGE_3D(vectorZ, sampler, pos).x);
+
+
+  //int4 coord_norm = (int4)(x2 * GET_IMAGE_WIDTH(input) / GET_IMAGE_WIDTH(output),y2 * GET_IMAGE_HEIGHT(input) / GET_IMAGE_HEIGHT(output), z2  * GET_IMAGE_DEPTH(input) / GET_IMAGE_DEPTH(output),0.f);
+  int4 coord_norm = (int4)(x2,y2, z2,0.f);
+
+
+
+  float pix = 0;
+  if (x2 >= 0 && y2 >= 0 && z2 >= 0 &&
+      x2 < GET_IMAGE_WIDTH(src) && y2 < GET_IMAGE_HEIGHT(src) && z2 < GET_IMAGE_DEPTH(src)
+  ) {
+    pix = (float)(READ_IMAGE_3D(src, sampler, coord_norm).x);
+  }
+
+  WRITE_IMAGE_3D(dst, pos, (DTYPE_OUT) pix);
+}
+
+
+__kernel void deform_2d(DTYPE_IMAGE_IN_2D src,
+                        DTYPE_IMAGE_IN_2D vectorX,
+                        DTYPE_IMAGE_IN_2D vectorY,
+ 	      			 DTYPE_IMAGE_OUT_2D dst)
+{
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_TRUE|
+      SAMPLER_ADDRESS |	SAMPLER_FILTER;
+
+  uint i = get_global_id(0);
+  uint j = get_global_id(1);
+
+  uint Nx = get_global_size(0);
+  uint Ny = get_global_size(1);
+
+  float x = i+0.5f;
+  float y = j+0.5f;
+
+
+  int2 pos = (int2){i, j};
+
+  float x2 = x + (float)(READ_IMAGE_2D(vectorX, sampler, pos).x);
+  float y2 = y + (float)(READ_IMAGE_2D(vectorY, sampler, pos).x);
+
+
+  int2 coord_norm = (int2)(x2, y2);
+
+  float pix = 0;
+  if (x2 >= 0 && y2 >= 0 &&
+      x2 < GET_IMAGE_WIDTH(src) && y2 < GET_IMAGE_HEIGHT(src)
+  ) {
+    pix = (float)(READ_IMAGE_2D(src, sampler, coord_norm).x);
+  }
+
+
+  WRITE_IMAGE_2D(dst, pos, (DTYPE_OUT) pix);
+}

--- a/src/main/java/clearcl/ocllib/kernels/deform_interpolate.cl
+++ b/src/main/java/clearcl/ocllib/kernels/deform_interpolate.cl
@@ -1,0 +1,89 @@
+
+#ifndef SAMPLER_FILTER
+#define SAMPLER_FILTER CLK_FILTER_LINEAR
+#endif
+
+#ifndef SAMPLER_ADDRESS
+#define SAMPLER_ADDRESS CLK_ADDRESS_CLAMP
+#endif
+
+__kernel void deform_3d_interpolate(DTYPE_IMAGE_IN_3D src,
+                        DTYPE_IMAGE_IN_3D vectorX,
+                        DTYPE_IMAGE_IN_3D vectorY,
+                        DTYPE_IMAGE_IN_3D vectorZ,
+	      			 DTYPE_IMAGE_OUT_3D dst)
+{
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_TRUE|
+      SAMPLER_ADDRESS |	SAMPLER_FILTER;
+
+  uint i = get_global_id(0);
+  uint j = get_global_id(1);
+  uint k = get_global_id(2);
+
+  uint Nx = GET_IMAGE_WIDTH(src);
+  uint Ny = GET_IMAGE_HEIGHT(src);
+  uint Nz = GET_IMAGE_DEPTH(src);
+
+  float x = i+0.5f;
+  float y = j+0.5f;
+  float z = k+0.5f;
+
+  int4 pos = (int4){i, j, k,0};
+
+  float x2 = x + (float)(READ_IMAGE_3D(vectorX, sampler, pos).x);
+  float y2 = y + (float)(READ_IMAGE_3D(vectorY, sampler, pos).x);
+  float z2 = z + (float)(READ_IMAGE_3D(vectorZ, sampler, pos).x);
+
+
+  //int4 coord_norm = (int4)(x2 * GET_IMAGE_WIDTH(input) / GET_IMAGE_WIDTH(output),y2 * GET_IMAGE_HEIGHT(input) / GET_IMAGE_HEIGHT(output), z2  * GET_IMAGE_DEPTH(input) / GET_IMAGE_DEPTH(output),0.f);
+  float4 coord_norm = (float4)(x2 / Nx, y2 / Ny, z2 / Nz,0.f);
+
+
+
+  float pix = 0;
+  if (x2 >= 0 && y2 >= 0 && z2 >= 0 &&
+      x2 < GET_IMAGE_WIDTH(src) && y2 < GET_IMAGE_HEIGHT(src) && z2 < GET_IMAGE_DEPTH(src)
+  ) {
+    pix = (float)(READ_IMAGE_3D(src, sampler, coord_norm).x);
+  }
+
+  WRITE_IMAGE_3D(dst, pos, (DTYPE_OUT) pix);
+}
+
+
+__kernel void deform_2d_interpolate(DTYPE_IMAGE_IN_2D src,
+                        DTYPE_IMAGE_IN_2D vectorX,
+                        DTYPE_IMAGE_IN_2D vectorY,
+ 	      			 DTYPE_IMAGE_OUT_2D dst)
+{
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_TRUE|
+      SAMPLER_ADDRESS |	SAMPLER_FILTER;
+
+  uint i = get_global_id(0);
+  uint j = get_global_id(1);
+
+  uint Nx = GET_IMAGE_WIDTH(src);
+  uint Ny = GET_IMAGE_HEIGHT(src);
+
+  float x = i+0.5f;
+  float y = j+0.5f;
+
+
+  int2 pos = (int2){i, j};
+
+  float x2 = x + (float)(READ_IMAGE_2D(vectorX, sampler, pos).x);
+  float y2 = y + (float)(READ_IMAGE_2D(vectorY, sampler, pos).x);
+
+
+  float2 coord_norm = (float2)(x2 / Nx, y2 / Ny);
+
+  float pix = 0;
+  if (x2 >= 0 && y2 >= 0 &&
+      x2 < GET_IMAGE_WIDTH(src) && y2 < GET_IMAGE_HEIGHT(src)
+  ) {
+    pix = (float)(READ_IMAGE_2D(src, sampler, coord_norm).x);
+  }
+
+
+  WRITE_IMAGE_2D(dst, pos, (DTYPE_OUT) pix);
+}

--- a/src/main/java/clearcl/ocllib/kernels/detection.cl
+++ b/src/main/java/clearcl/ocllib/kernels/detection.cl
@@ -1,0 +1,132 @@
+
+__kernel void detect_local_optima_3d(
+        DTYPE_IMAGE_IN_3D src,
+        DTYPE_IMAGE_OUT_3D dst,
+        __private int radius,
+        __private int detect_maxima
+)
+{
+    const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+    int4 pos = {get_global_id(0), get_global_id(1), get_global_id(2), 0};
+    float localMin = READ_IMAGE_3D(src, sampler, pos).x + 1;
+    float localMax = localMin - 2;
+    int4 localMinPos = pos;
+    int4 localMaxPos = pos;
+
+    for(int x = -radius; x < radius + 1; x++)
+    {
+        for(int y = -radius; y < radius + 1; y++)
+        {
+            for(int z = -radius; z < radius + 1; z++)
+            {
+                const int4 localPos = pos + (int4){ x, y, z, 0};
+
+                float value = READ_IMAGE_3D(src, sampler, localPos).x;
+
+                if (value < localMin) {
+                    localMin = value;
+                    localMinPos = localPos;
+                }
+                if (value > localMax) {
+                    localMax = value;
+                    localMaxPos = localPos;
+                }
+            }
+        }
+    }
+
+    if ((detect_maxima == 1 && pos.x == localMaxPos.x && pos.y == localMaxPos.y && pos.z == localMaxPos.z) ||
+        (pos.x == localMinPos.x && pos.y == localMinPos.y && pos.z == localMinPos.z)) {
+        WRITE_IMAGE_3D(dst, pos, ((DTYPE_OUT){1, 0, 0, 0}));
+    } else {
+        WRITE_IMAGE_3D(dst, pos, ((DTYPE_OUT){0, 0, 0, 0}));
+    }
+}
+
+
+__kernel void detect_local_optima_3d_slice_by_slice(
+        DTYPE_IMAGE_IN_3D src,
+        DTYPE_IMAGE_OUT_3D dst,
+        __private int radius,
+        __private int detect_maxima
+)
+{
+    const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+    int4 pos = {get_global_id(0), get_global_id(1), get_global_id(2), 0};
+    float localMin = READ_IMAGE_3D(src, sampler, pos).x + 1;
+    float localMax = localMin - 2;
+    int4 localMinPos = pos;
+    int4 localMaxPos = pos;
+
+    for(int x = -radius; x < radius + 1; x++)
+    {
+        for(int y = -radius; y < radius + 1; y++)
+        {
+            int z = 0;
+            const int4 localPos = pos + (int4){ x, y, z, 0};
+
+            float value = READ_IMAGE_3D(src, sampler, localPos).x;
+
+            if (value < localMin) {
+                localMin = value;
+                localMinPos = localPos;
+            }
+            if (value > localMax) {
+                localMax = value;
+                localMaxPos = localPos;
+            }
+        }
+    }
+
+    if ((detect_maxima == 1 && pos.x == localMaxPos.x && pos.y == localMaxPos.y) ||
+        (pos.x == localMinPos.x && pos.y == localMinPos.y)) {
+        WRITE_IMAGE_3D(dst, pos, ((DTYPE_OUT){1, 0, 0, 0}));
+    } else {
+        WRITE_IMAGE_3D(dst, pos, ((DTYPE_OUT){0, 0, 0, 0}));
+    }
+}
+
+__kernel void detect_local_optima_2d(
+        DTYPE_IMAGE_IN_2D src,
+        DTYPE_IMAGE_OUT_2D dst,
+        __private int radius,
+        __private int detect_maxima
+)
+{
+    const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+    int2 pos = {get_global_id(0), get_global_id(1)};
+    float localMin = READ_IMAGE_2D(src, sampler, pos).x + 1;
+    float localMax = localMin - 2;
+    int2 localMinPos = pos;
+    int2 localMaxPos = pos;
+
+    for(int x = -radius; x < radius + 1; x++)
+    {
+        for(int y = -radius; y < radius + 1; y++)
+        {
+            const int2 localPos = pos + (int2){ x, y};
+
+            float value = READ_IMAGE_2D(src, sampler, localPos).x;
+
+            if (value < localMin) {
+                localMin = value;
+                localMinPos = localPos;
+            }
+            if (value > localMax) {
+                localMax = value;
+                localMaxPos = localPos;
+            }
+
+        }
+    }
+
+    if ((detect_maxima == 1 && pos.x == localMaxPos.x && pos.y == localMaxPos.y) ||
+        (pos.x == localMinPos.x && pos.y == localMinPos.y)) {
+        WRITE_IMAGE_2D(dst, pos, ((DTYPE_OUT)1));
+    } else {
+        WRITE_IMAGE_2D(dst, pos, ((DTYPE_OUT)0));
+    }
+}

--- a/src/main/java/clearcl/ocllib/kernels/differenceOfGaussian.cl
+++ b/src/main/java/clearcl/ocllib/kernels/differenceOfGaussian.cl
@@ -1,0 +1,146 @@
+
+__kernel void subtract_convolved_images_3d_fast(
+       DTYPE_IMAGE_IN_3D src,
+       DTYPE_IMAGE_OUT_3D dst,
+        __private int radius,
+        __private float sigma_minuend,
+        __private float sigma_subtrahend
+)
+{
+    const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+    int4 pos = {get_global_id(0), get_global_id(1), get_global_id(2), 0};
+
+    float sum_minuend = 0.0f;
+    float sum_subtrahend = 0.0f;
+    float weighted_sum_minuend = 0.0f;
+    float weighted_sum_subtrahend = 0.0f;
+
+    for(int x = -radius; x < radius + 1; x++)
+    {
+        for(int y = -radius; y < radius + 1; y++)
+        {
+            for(int z = -radius; z < radius + 1; z++)
+            {
+                const int4 kernelPos = {x+radius, y+radius, z+radius, 0};
+                const int4 imagePos = pos + (int4){ x, y, z, 0};
+
+                float image_pixel_value = READ_IMAGE_3D(src, sampler, imagePos).x;
+
+                float weight_minuend = exp(-((float) (x * x + y * y + z * z) / (3.0f
+                                                              * sigma_minuend
+                                                              * sigma_minuend
+                                                              * sigma_minuend)));
+                float weight_subtrahend = exp(-((float) (x * x + y * y + z * z) / (3.0f
+                                                              * sigma_subtrahend
+                                                              * sigma_subtrahend
+                                                              * sigma_subtrahend)));
+
+                weighted_sum_minuend += weight_minuend * image_pixel_value;
+                weighted_sum_subtrahend += weight_subtrahend * image_pixel_value;
+
+                sum_minuend += weight_minuend;
+                sum_subtrahend += weight_subtrahend;
+            }
+        }
+    }
+
+    float pix = weighted_sum_minuend / sum_minuend  - weighted_sum_subtrahend / sum_subtrahend; //,0,0,0};
+	WRITE_IMAGE_3D(dst, pos, (DTYPE_OUT)pix);
+}
+
+
+__kernel void subtract_convolved_images_3d_slice_by_slice(
+        DTYPE_IMAGE_IN_3D src,
+        DTYPE_IMAGE_OUT_3D dst,
+        __private int radius,
+        __private float sigma_minuend,
+        __private float sigma_subtrahend
+)
+{
+    const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+    int4 pos = {get_global_id(0), get_global_id(1), get_global_id(2), 0};
+
+    float sum_minuend = 0.0f;
+    float sum_subtrahend = 0.0f;
+    float weighted_sum_minuend = 0.0f;
+    float weighted_sum_subtrahend = 0.0f;
+
+    for(int x = -radius; x < radius + 1; x++)
+    {
+        for(int y = -radius; y < radius + 1; y++)
+        {
+            int z = 0;
+            const int4 kernelPos = {x+radius, y+radius, z+radius, 0};
+            const int4 imagePos = pos + (int4){ x, y, z, 0};
+
+            float image_pixel_value = READ_IMAGE_3D(src, sampler, imagePos).x;
+
+            float weight_minuend = exp(-((float) (x * x + y * y + z * z) / (3.0f
+                                                          * sigma_minuend
+                                                          * sigma_minuend
+                                                          * sigma_minuend)));
+            float weight_subtrahend = exp(-((float) (x * x + y * y + z * z) / (3.0f
+                                                          * sigma_subtrahend
+                                                          * sigma_subtrahend
+                                                          * sigma_subtrahend)));
+
+            weighted_sum_minuend += weight_minuend * image_pixel_value;
+            weighted_sum_subtrahend += weight_subtrahend * image_pixel_value;
+
+            sum_minuend += weight_minuend;
+            sum_subtrahend += weight_subtrahend;
+        }
+    }
+
+    float pix = weighted_sum_minuend / sum_minuend  - weighted_sum_subtrahend / sum_subtrahend;
+	WRITE_IMAGE_3D(dst, pos, (DTYPE_OUT)pix);
+}
+
+__kernel void subtract_convolved_images_2d_fast(
+        DTYPE_IMAGE_IN_2D src,
+        DTYPE_IMAGE_OUT_2D dst,
+        __private int radius,
+        __private float sigma_minuend,
+        __private float sigma_subtrahend
+)
+{
+    const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+    int2 pos = {get_global_id(0), get_global_id(1)};
+
+    float sum_minuend = 0.0f;
+    float sum_subtrahend = 0.0f;
+    float weighted_sum_minuend = 0.0f;
+    float weighted_sum_subtrahend = 0.0f;
+
+    for(int x = -radius; x < radius + 1; x++)
+    {
+        for(int y = -radius; y < radius + 1; y++)
+        {
+            const int2 kernelPos = {x+radius, y+radius};
+            const int2 imagePos = pos + (int2){ x, y};
+
+            float image_pixel_value = READ_IMAGE_2D(src, sampler, imagePos).x;
+
+            float weight_minuend = exp(-((float) (x * x + y * y) / (2.0f
+                                                          * sigma_minuend
+                                                          * sigma_minuend)));
+            float weight_subtrahend = exp(-((float) (x * x + y * y) / (2.0f
+                                                          * sigma_subtrahend
+                                                          * sigma_subtrahend)));
+
+            weighted_sum_minuend += weight_minuend * image_pixel_value;
+            weighted_sum_subtrahend += weight_subtrahend * image_pixel_value;
+
+            sum_minuend += weight_minuend;
+            sum_subtrahend += weight_subtrahend;
+
+        }
+    }
+
+    float pix = weighted_sum_minuend / sum_minuend  - weighted_sum_subtrahend / sum_subtrahend; //,0,0,0};
+	WRITE_IMAGE_2D(dst, pos, (DTYPE_OUT)pix);
+}
+

--- a/src/main/java/clearcl/ocllib/kernels/downsampling.cl
+++ b/src/main/java/clearcl/ocllib/kernels/downsampling.cl
@@ -1,0 +1,147 @@
+__kernel void downsample_3d_nearest(DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src, float factor_x, float factor_y, float factor_z) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int dx = get_global_id(0);
+  const int dy = get_global_id(1);
+  const int dz = get_global_id(2);
+
+  const int sx = factor_x * dx;
+  const int sy = factor_y * dy;
+  const int sz = factor_z * dz;
+  const DTYPE_IN out = READ_IMAGE_3D(src,sampler,((int4){sx,sy,sz,0})).x;
+  WRITE_IMAGE_3D(dst,((int4){dx,dy,dz,0}),(DTYPE_OUT)out);
+}
+
+__kernel void downsample_2d_nearest(DTYPE_IMAGE_OUT_2D dst, DTYPE_IMAGE_IN_2D src, float factor_x, float factor_y) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int dx = get_global_id(0);
+  const int dy = get_global_id(1);
+
+  const int sx = factor_x * dx;
+  const int sy = factor_y * dy;
+  const DTYPE_IN out = READ_IMAGE_2D(src,sampler,((int2){sx,sy})).x;
+  WRITE_IMAGE_2D(dst,((int2){dx,dy}),(DTYPE_OUT)out);
+}
+
+#define SIZEX 4
+#define SIZEY 4
+#define SIZETotal SIZEX * SIZEY
+
+__kernel void DownSample ( DTYPE_IMAGE_IN_2D src,
+                                                 DTYPE_IMAGE_OUT_2D des,
+                                                 __constant int * dim // "constant" memory (64K) pre-cached so it can be read fast
+                                )
+{
+    // tell the sampler how to read the image
+    const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_FILTER_NEAREST;
+
+    int i = get_global_id (0);
+    int j = get_global_id (1);
+
+   // jump to the starting indexes
+   int is = i * SIZEX;
+   int js = j * SIZEY;
+
+   if ( is >= dim[0] - SIZEX && js >= dim[1] - SIZEY )
+       return;
+
+   DTYPE_OUT total = 0;
+
+   // we can unroll the loop to reduce overhead (e.g., condition check)
+   // if you know the size (e.g., 4 * 4 ), then you can write 16 separate
+   // "read_imageui" instead of using the loop
+   // There is a way for CPU to generate the unrolled code to be
+   // placed in the kernel.
+   for ( int z = 0; z < SIZEX; z++ ) {
+       for ( int x = 0; x < SIZEX; x++ ) {
+            for ( int y = 0; y < SIZEY; y++ ) {
+                if ( is < dim[0] - x && js < dim[1] - y ) {
+                    total += (READ_IMAGE_2D ( src, sampler, ((int2) { is + x, js + y }) )).x;
+                }
+            }
+        }
+    }
+
+    total = (DTYPE_OUT) ( total / SIZETotal );
+    WRITE_IMAGE_2D ( des, ((int2) { i, j }), total );
+}
+
+
+// the following two methods originate from
+// https://github.com/ClearControl/fastfuse/blob/master/src/main/java/fastfuse/tasks/kernels/downsampling.cl
+
+#define min_nobranch(x,y) x < y ? x : y;
+#define max_nobranch(x,y) x > y ? x : y;
+
+inline void swap(DTYPE_IN *a, int i, int j) {
+  DTYPE_IN t;
+  t    = min_nobranch(a[i],a[j]);
+  a[j] = max_nobranch(a[i],a[j]);
+  a[i] = t;
+}
+
+
+__kernel void downsample_xy_by_half_median(DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src) {
+
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord_out = (int4){i,j,k,0};
+  const int x = 2*i, y = 2*j, z = k;
+
+  DTYPE_IN pixel[4];
+  pixel[0] = READ_IMAGE_3D(src,sampler,((int4){x+0,y+0,z,0})).x;
+  pixel[1] = READ_IMAGE_3D(src,sampler,((int4){x+0,y+1,z,0})).x;
+  pixel[2] = READ_IMAGE_3D(src,sampler,((int4){x+1,y+0,z,0})).x;
+  pixel[3] = READ_IMAGE_3D(src,sampler,((int4){x+1,y+1,z,0})).x;
+
+  // // sort pixel array
+  // swap(pixel,0,1);
+  // swap(pixel,2,3);
+  // swap(pixel,0,2);
+  // swap(pixel,1,3);
+  // swap(pixel,1,2);
+
+  // if ((pixel[0] > pixel[1]) ||
+  //     (pixel[1] > pixel[2]) ||
+  //     (pixel[2] > pixel[3]))
+  //   printf("array not sorted for i=%d, j=%d, k=%d\n", i,j,k);
+
+  // swap array elements such that pixel[0] = "min(pixel)" and pixel[3] = "max(pixel)"
+  // this tiny performance improvement is only there to make Martin happy
+  swap(pixel,0,1);
+  swap(pixel,2,3);
+  swap(pixel,0,2);
+  swap(pixel,1,3);
+
+  // if ( (pixel[0] > pixel[1]) || (pixel[0] > pixel[2]) || (pixel[0] > pixel[3]) ||
+  //      (pixel[3] < pixel[2]) || (pixel[3] < pixel[1]) || (pixel[3] < pixel[0]) )
+  //   printf("array not sorted for i=%d, j=%d, k=%d\n", i,j,k);
+
+  // output is mean of medians
+  const float out = (pixel[1] + pixel[2]) / 2.0f;
+
+  WRITE_IMAGE_3D(dst,coord_out,(DTYPE_OUT)out);
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/main/java/clearcl/ocllib/kernels/duplication.cl
+++ b/src/main/java/clearcl/ocllib/kernels/duplication.cl
@@ -1,0 +1,89 @@
+__kernel void copy_3d (DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int dx = get_global_id(0);
+  const int dy = get_global_id(1);
+  const int dz = get_global_id(2);
+
+  const int4 pos = (int4){dx,dy,dz,0};
+
+  const DTYPE_IN out = READ_IMAGE_3D(src,sampler,pos).x;
+  WRITE_IMAGE_3D(dst, pos,(DTYPE_OUT)out);
+}
+
+__kernel void copy_2d(DTYPE_IMAGE_OUT_2D dst, DTYPE_IMAGE_IN_2D src) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int dx = get_global_id(0);
+  const int dy = get_global_id(1);
+
+
+  const int2 pos = (int2){dx,dy};
+
+  const DTYPE_IN out = READ_IMAGE_2D(src,sampler,pos).x;
+  WRITE_IMAGE_2D(dst,pos,(DTYPE_OUT)out);
+}
+
+__kernel void copySlice(DTYPE_IMAGE_OUT_2D dst, DTYPE_IMAGE_IN_3D src, int slice) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int dx = get_global_id(0);
+  const int dy = get_global_id(1);
+
+  const int4 pos4 = (int4){dx,dy,slice,0};
+  const int2 pos2 = (int2){dx,dy};
+
+  const DTYPE_IN out = READ_IMAGE_3D(src,sampler,pos4).x;
+  WRITE_IMAGE_2D(dst,pos2,(DTYPE_OUT)out);
+}
+
+__kernel void putSliceInStack(DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_2D src, int slice) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int dx = get_global_id(0);
+  const int dy = get_global_id(1);
+
+  const int2 pos2 = (int2){dx,dy};
+  const int4 pos4 = (int4){dx,dy,slice,0};
+
+  const DTYPE_IN out = READ_IMAGE_2D(src,sampler,pos2).x;
+  WRITE_IMAGE_3D(dst,pos4,(DTYPE_OUT)out);
+}
+
+
+__kernel void crop_3d(DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src, int start_x, int start_y, int start_z) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int dx = get_global_id(0);
+  const int dy = get_global_id(1);
+  const int dz = get_global_id(2);
+
+
+  const int sx = start_x + dx;
+  const int sy = start_y + dy;
+  const int sz = start_z + dz;
+
+  const int4 dpos = (int4){dx,dy,dz,0};
+  const int4 spos = (int4){sx,sy,sz,0};
+
+  const DTYPE_IN out = READ_IMAGE_3D(src,sampler,spos).x;
+  WRITE_IMAGE_3D(dst,dpos,(DTYPE_OUT)out);
+}
+
+
+__kernel void crop_2d(DTYPE_IMAGE_OUT_2D dst, DTYPE_IMAGE_IN_2D src, int start_x, int start_y) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int dx = get_global_id(0);
+  const int dy = get_global_id(1);
+
+  const int sx = start_x + dx;
+  const int sy = start_y + dy;
+
+  const int2 dpos = (int2){dx,dy};
+  const int2 spos = (int2){sx,sy};
+
+  const DTYPE_IN out = READ_IMAGE_2D(src,sampler,spos).x;
+  WRITE_IMAGE_2D(dst,dpos,(DTYPE_OUT)out);
+}
+

--- a/src/main/java/clearcl/ocllib/kernels/filtering.cl
+++ b/src/main/java/clearcl/ocllib/kernels/filtering.cl
@@ -1,0 +1,844 @@
+__constant sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+
+inline int copyNeighborhoodToArray(DTYPE_IMAGE_IN_2D src, DTYPE_OUT array[],
+                                    const int2 coord,
+                                    const int Nx, const int Ny ) {
+    // centers
+    const int4   e = (int4)  { (Nx-1)/2, (Ny-1)/2, 0, 0 };
+
+    float aSquared = e.x * e.x;
+    float bSquared = e.y * e.y;
+
+    int count = 0;
+
+    for (int x = -e.x; x <= e.x; x++) {
+        float xSquared = x * x;
+        for (int y = -e.y; y <= e.y; y++) {
+            float ySquared = y * y;
+            if (xSquared / aSquared + ySquared / bSquared <= 1.0) {
+                array[count] = (DTYPE_OUT)READ_IMAGE_2D(src,sampler,coord+((int2){x,y})).x;
+                count++;
+            }
+        }
+    }
+    return count;
+}
+
+inline int copyBoxNeighborhoodToArray(DTYPE_IMAGE_IN_2D src, DTYPE_OUT array[],
+                                    const int2 coord,
+                                    const int Nx, const int Ny ) {
+    // centers
+    const int4   e = (int4)  { (Nx-1)/2, (Ny-1)/2, 0, 0 };
+
+    float aSquared = e.x * e.x;
+    float bSquared = e.y * e.y;
+
+    int count = 0;
+
+    for (int x = -e.x; x <= e.x; x++) {
+        for (int y = -e.y; y <= e.y; y++) {
+            array[count] = (DTYPE_OUT)READ_IMAGE_2D(src,sampler,coord+((int2){x,y})).x;
+            count++;
+        }
+    }
+    return count;
+}
+
+inline int copySliceNeighborhoodToArray(DTYPE_IMAGE_IN_3D src, DTYPE_OUT array[],
+                                    const int4 coord,
+                                    const int Nx, const int Ny ) {
+    // centers
+    const int4   e = (int4)  { (Nx-1)/2, (Ny-1)/2, 0, 0 };
+
+    float aSquared = e.x * e.x;
+    float bSquared = e.y * e.y;
+
+    int count = 0;
+
+    for (int x = -e.x; x <= e.x; x++) {
+        float xSquared = x * x;
+        for (int y = -e.y; y <= e.y; y++) {
+            float ySquared = y * y;
+            if (xSquared / aSquared + ySquared / bSquared <= 1.0) {
+                array[count] = (DTYPE_OUT)READ_IMAGE_3D(src,sampler,coord+((int4){x,y,0,0})).x;
+                count++;
+            }
+        }
+    }
+    return count;
+}
+
+inline int copyBoxSliceNeighborhoodToArray(DTYPE_IMAGE_IN_3D src, DTYPE_OUT array[],
+                                    const int4 coord,
+                                    const int Nx, const int Ny ) {
+    // centers
+    const int4   e = (int4)  { (Nx-1)/2, (Ny-1)/2, 0, 0 };
+
+    float aSquared = e.x * e.x;
+    float bSquared = e.y * e.y;
+
+    int count = 0;
+
+    for (int x = -e.x; x <= e.x; x++) {
+        float xSquared = x * x;
+        for (int y = -e.y; y <= e.y; y++) {
+            array[count] = (DTYPE_OUT)READ_IMAGE_3D(src,sampler,coord+((int4){x,y,0,0})).x;
+            count++;
+        }
+    }
+    return count;
+}
+
+
+inline int copyVolumeNeighborhoodToArray(DTYPE_IMAGE_IN_3D src, DTYPE_OUT array[],
+                                    const int4 coord,
+                                    const int Nx, const int Ny, const int Nz ) {
+    // centers
+    const int4   e = (int4)  {(Nx-1)/2, (Ny-1)/2, (Nz-1)/2, 0 };
+
+    int count = 0;
+
+    float aSquared = e.x * e.x;
+    float bSquared = e.y * e.y;
+    float cSquared = e.z * e.z;
+
+    for (int x = -e.x; x <= e.x; x++) {
+        float xSquared = x * x;
+        for (int y = -e.y; y <= e.y; y++) {
+            float ySquared = y * y;
+            for (int z = -e.z; z <= e.z; z++) {
+                float zSquared = z * z;
+                if (xSquared / aSquared + ySquared / bSquared + zSquared / cSquared <= 1.0) {
+
+                    int x1 = coord.x + x;
+                    int x2 = coord.y + y;
+                    int x3 = coord.z + z;
+                    const int4 pos = (int4){x1,x2,x3,0};
+                    float value_res = (float)READ_IMAGE_3D(src,sampler,pos).x;
+                    array[count] = value_res;
+                    count++;
+                }
+            }
+        }
+    }
+    return count;
+}
+
+inline int copyBoxVolumeNeighborhoodToArray(DTYPE_IMAGE_IN_3D src, DTYPE_OUT array[],
+                                    const int4 coord,
+                                    const int Nx, const int Ny, const int Nz ) {
+    // centers
+    const int4   e = (int4)  {(Nx-1)/2, (Ny-1)/2, (Nz-1)/2, 0 };
+
+    int count = 0;
+
+    float aSquared = e.x * e.x;
+    float bSquared = e.y * e.y;
+    float cSquared = e.z * e.z;
+
+    for (int x = -e.x; x <= e.x; x++) {
+        for (int y = -e.y; y <= e.y; y++) {
+            for (int z = -e.z; z <= e.z; z++) {
+                int x1 = coord.x + x;
+                int x2 = coord.y + y;
+                int x3 = coord.z + z;
+                const int4 pos = (int4){x1,x2,x3,0};
+                float value_res = (float)READ_IMAGE_3D(src,sampler,pos).x;
+                array[count] = value_res;
+                count++;
+
+            }
+        }
+    }
+    return count;
+}
+
+
+inline void sort(DTYPE_OUT array[], int array_size)
+{
+    DTYPE_OUT temp;
+    for(int i = 0; i < array_size; i++) {
+        int j;
+        temp = array[i];
+        for(j = i - 1; j >= 0 && temp < array[j]; j--) {
+            array[j+1] = array[j];
+        }
+        array[j+1] = temp;
+    }
+}
+
+inline DTYPE_OUT average(DTYPE_OUT array[], int array_size)
+{
+    DTYPE_OUT sum = 0;
+    for(int i = 0; i < array_size; i++) {
+        sum += array[i];
+    }
+    return sum / array_size;
+}
+
+inline DTYPE_OUT median(DTYPE_OUT array[], int array_size)
+{
+    sort(array, array_size);
+    return array[array_size / 2];
+}
+
+__kernel void mean_slicewise_image3d
+(
+  DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src,
+  const int Nx, const int Ny
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4){i,j,k,0};
+
+    const int4   e = (int4)  {(Nx-1)/2, (Ny-1)/2, 0, 0 };
+
+    float aSquared = e.x * e.x;
+    float bSquared = e.y * e.y;
+
+    DTYPE_OUT sum = 0;
+    int count = 0;
+
+    for (int x = -e.x; x <= e.x; x++) {
+        float xSquared = x * x;
+        for (int y = -e.y; y <= e.y; y++) {
+            float ySquared = y * y;
+            if (xSquared / aSquared + ySquared / bSquared <= 1.0) {
+                sum += (DTYPE_OUT)READ_IMAGE_3D(src,sampler,coord+((int4){x,y,0,0})).x;
+                count++;
+            }
+        }
+    }
+
+  DTYPE_OUT res = sum / count;
+  WRITE_IMAGE_3D(dst, coord, res);
+}
+
+__kernel void mean_image2d_ij
+(
+  DTYPE_IMAGE_OUT_2D dst, DTYPE_IMAGE_IN_2D src,
+  const int radius
+)
+{
+    const int i = get_global_id(0), j = get_global_id(1);
+    const int2 coord = (int2){i,j};
+
+    // centers
+    const int4   e = (int4)  { radius, radius, 0, 0 };
+
+    float rSquared = pow((float)radius, 2) + 1;
+
+    int count = 0;
+
+    float sum = 0;
+    for (int x = -e.x; x <= e.x; x++) {
+        float xSquared = x * x;
+        for (int y = -e.y; y <= e.y; y++) {
+            float ySquared = y * y;
+            if (xSquared + ySquared <= rSquared) {
+                sum += (float)(READ_IMAGE_2D(src,sampler,coord+((int2){x,y})).x);
+                count++;
+            }
+        }
+    }
+
+
+    DTYPE_OUT res = (sum / count + 0.5);
+    WRITE_IMAGE_2D(dst, coord, res);
+}
+
+
+__kernel void mean_image2d
+(
+  DTYPE_IMAGE_OUT_2D dst, DTYPE_IMAGE_IN_2D src,
+  const int Nx, const int Ny
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1);
+  const int2 coord = (int2){i,j};
+
+    const int4   e = (int4)  {(Nx-1)/2, (Ny-1)/2, 0, 0 };
+    int count = 0;
+    float sum = 0;
+
+    float aSquared = e.x * e.x;
+    float bSquared = e.y * e.y;
+
+  for (int x = -e.x; x <= e.x; x++) {
+      float xSquared = x * x;
+      for (int y = -e.y; y <= e.y; y++) {
+          float ySquared = y * y;
+          if (xSquared / aSquared + ySquared / bSquared <= 1.0) {
+              sum += (DTYPE_OUT)READ_IMAGE_2D(src,sampler,coord+((int2){x,y})).x;
+              count++;
+          }
+      }
+  }
+
+  DTYPE_OUT res = sum / count;
+  WRITE_IMAGE_2D(dst, coord, res);
+}
+
+__kernel void mean_image3d
+(
+  DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src,
+  const int Nx, const int Ny, const int Nz
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4){i,j,k,0};
+
+    const int4   e = (int4)  {(Nx-1)/2, (Ny-1)/2, (Nz-1)/2, 0 };
+    int count = 0;
+    float sum = 0;
+
+    float aSquared = e.x * e.x;
+    float bSquared = e.y * e.y;
+    float cSquared = e.z * e.z;
+
+    for (int x = -e.x; x <= e.x; x++) {
+        float xSquared = x * x;
+        for (int y = -e.y; y <= e.y; y++) {
+            float ySquared = y * y;
+            for (int z = -e.z; z <= e.z; z++) {
+                float zSquared = z * z;
+                if (xSquared / aSquared + ySquared / bSquared + zSquared / cSquared <= 1.0) {
+
+                    int x1 = coord.x + x;
+                    int x2 = coord.y + y;
+                    int x3 = coord.z + z;
+                    const int4 pos = (int4){x1,x2,x3,0};
+                    float value_res = (float)READ_IMAGE_3D(src,sampler,pos).x;
+                    sum += value_res;
+                    count++;
+                }
+            }
+        }
+    }
+
+
+  DTYPE_OUT res = sum / count;
+  WRITE_IMAGE_3D(dst, coord, res);
+}
+
+__kernel void median_image2d
+(
+  DTYPE_IMAGE_OUT_2D dst, DTYPE_IMAGE_IN_2D src,
+  const int Nx, const int Ny
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1);
+  const int2 coord = (int2){i,j};
+
+  int array_size = Nx * Ny;
+  DTYPE_OUT array[MAX_ARRAY_SIZE];
+
+  array_size = copyNeighborhoodToArray(src, array, coord, Nx, Ny);
+
+  DTYPE_OUT res = median(array, array_size);
+  WRITE_IMAGE_2D(dst, coord, res);
+}
+
+__kernel void median_box_image2d
+(
+  DTYPE_IMAGE_OUT_2D dst, DTYPE_IMAGE_IN_2D src,
+  const int Nx, const int Ny
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1);
+  const int2 coord = (int2){i,j};
+
+  int array_size = Nx * Ny;
+  DTYPE_OUT array[MAX_ARRAY_SIZE];
+
+  array_size = copyBoxNeighborhoodToArray(src, array, coord, Nx, Ny);
+
+  DTYPE_OUT res = median(array, array_size);
+  WRITE_IMAGE_2D(dst, coord, res);
+}
+
+__kernel void median_image3d
+(
+  DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src,
+  const int Nx, const int Ny, const int Nz
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4){i,j,k,0};
+
+  int array_size = Nx * Ny * Nz;
+  DTYPE_OUT array[MAX_ARRAY_SIZE];
+
+  array_size = copyVolumeNeighborhoodToArray(src, array, coord, Nx, Ny, Nz);
+
+  DTYPE_OUT res = median(array, array_size);
+  WRITE_IMAGE_3D(dst, coord, res);
+}
+
+__kernel void median_box_image3d
+(
+  DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src,
+  const int Nx, const int Ny, const int Nz
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4){i,j,k,0};
+
+  int array_size = Nx * Ny * Nz;
+  DTYPE_OUT array[MAX_ARRAY_SIZE];
+
+  array_size = copyBoxVolumeNeighborhoodToArray(src, array, coord, Nx, Ny, Nz);
+
+  DTYPE_OUT res = median(array, array_size);
+  WRITE_IMAGE_3D(dst, coord, res);
+}
+
+__kernel void median_slicewise_image3d
+(
+  DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src,
+  const int Nx, const int Ny
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4){i,j,k,0};
+
+  int array_size = Nx * Ny;
+  DTYPE_OUT array[MAX_ARRAY_SIZE];
+
+  array_size = copySliceNeighborhoodToArray(src, array, coord, Nx, Ny);
+
+  DTYPE_OUT res = median(array, array_size);
+  WRITE_IMAGE_3D(dst, coord, res);
+}
+
+__kernel void median_box_slicewise_image3d
+(
+  DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src,
+  const int Nx, const int Ny
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4){i,j,k,0};
+
+  int array_size = Nx * Ny;
+  DTYPE_OUT array[MAX_ARRAY_SIZE];
+
+  array_size = copyBoxSliceNeighborhoodToArray(src, array, coord, Nx, Ny);
+
+  DTYPE_OUT res = median(array, array_size);
+  WRITE_IMAGE_3D(dst, coord, res);
+}
+
+__kernel void minimum_slicewise_image3d
+(
+  DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src,
+  const int Nx, const int Ny
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4){i,j,k,0};
+
+    const int4   e = (int4)  {(Nx-1)/2, (Ny-1)/2, 0, 0 };
+
+    DTYPE_OUT minimumValue = (DTYPE_OUT)READ_IMAGE_3D(src,sampler,coord).x;
+    float aSquared = e.x * e.x;
+    float bSquared = e.y * e.y;
+
+    for (int x = -e.x; x <= e.x; x++) {
+        float xSquared = x * x;
+        for (int y = -e.y; y <= e.y; y++) {
+            float ySquared = y * y;
+            if (xSquared / aSquared + ySquared / bSquared <= 1.0) {
+                DTYPE_OUT value = (DTYPE_OUT)READ_IMAGE_3D(src,sampler,coord+((int4){x,y,0,0})).x;
+                if (value < minimumValue) {
+                    minimumValue = value;
+                }
+            }
+        }
+    }
+
+  DTYPE_OUT res = minimumValue;
+  WRITE_IMAGE_3D(dst, coord, res);
+}
+
+
+__kernel void minimum_image2d
+(
+  DTYPE_IMAGE_OUT_2D dst, DTYPE_IMAGE_IN_2D src,
+  const int Nx, const int Ny
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1);
+  const int2 coord = (int2){i,j};
+
+    const int4   e = (int4)  { (Nx-1)/2, (Ny-1)/2, 0, 0 };
+
+    DTYPE_OUT minimumValue = (DTYPE_OUT)READ_IMAGE_2D(src,sampler,coord).x;
+    float aSquared = e.x * e.x;
+    float bSquared = e.y * e.y;
+
+    int count = 0;
+
+    for (int x = -e.x; x <= e.x; x++) {
+        float xSquared = x * x;
+        for (int y = -e.y; y <= e.y; y++) {
+            float ySquared = y * y;
+            if (xSquared / aSquared + ySquared / bSquared <= 1.0) {
+                DTYPE_OUT value = (DTYPE_OUT)READ_IMAGE_2D(src,sampler,coord+((int2){x,y})).x;
+                if (value < minimumValue) {
+                    minimumValue = value;
+                }
+            }
+        }
+    }
+
+  DTYPE_OUT res = minimumValue;
+  WRITE_IMAGE_2D(dst, coord, res);
+}
+
+__kernel void minimum_image2d_ij
+(
+  DTYPE_IMAGE_OUT_2D dst, DTYPE_IMAGE_IN_2D src,
+  const int radius
+)
+{
+    const int i = get_global_id(0), j = get_global_id(1);
+    const int2 coord = (int2){i,j};
+
+    // centers
+    const int4   e = (int4)  { radius, radius, 0, 0 };
+
+    float rSquared = pow((float)radius, 2) + 1;
+
+    float minimumValue = (float)(READ_IMAGE_2D(src,sampler,coord).x);
+    for (int x = -e.x; x <= e.x; x++) {
+        float xSquared = x * x;
+        for (int y = -e.y; y <= e.y; y++) {
+            float ySquared = y * y;
+            if (xSquared + ySquared <= rSquared) {
+                float value = (float)(READ_IMAGE_2D(src,sampler,coord+((int2){x,y})).x);
+                if (value < minimumValue) {
+                    minimumValue = value;
+                }
+            }
+        }
+    }
+
+    DTYPE_OUT res = minimumValue;
+    WRITE_IMAGE_2D(dst, coord, res);
+}
+
+
+__kernel void minimum_image3d
+(
+  DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src,
+  const int Nx, const int Ny, const int Nz
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4){i,j,k,0};
+
+    const int4   e = (int4)  {(Nx-1)/2, (Ny-1)/2, (Nz-1)/2, 0 };
+    float minimumValue = (float)READ_IMAGE_3D(src,sampler,coord).x;
+    float aSquared = e.x * e.x;
+    float bSquared = e.y * e.y;
+    float cSquared = e.z * e.z;
+
+    for (int x = -e.x; x <= e.x; x++) {
+        float xSquared = x * x;
+        for (int y = -e.y; y <= e.y; y++) {
+            float ySquared = y * y;
+            for (int z = -e.z; z <= e.z; z++) {
+                float zSquared = z * z;
+                if (xSquared / aSquared + ySquared / bSquared + zSquared / cSquared <= 1.0) {
+
+                    int x1 = coord.x + x;
+                    int x2 = coord.y + y;
+                    int x3 = coord.z + z;
+                    const int4 pos = (int4){x1,x2,x3,0};
+                    float value_res = (float)READ_IMAGE_3D(src,sampler,pos).x;
+                    if (value_res < minimumValue) {
+                        minimumValue = value_res;
+                    }
+                }
+            }
+        }
+    }
+
+
+  DTYPE_OUT res = minimumValue;
+  WRITE_IMAGE_3D(dst, coord, res);
+}
+
+__kernel void maximum_slicewise_image3d
+(
+  DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src,
+  const int Nx, const int Ny
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4){i,j,k,0};
+
+    const int4   e = (int4)  {(Nx-1)/2, (Ny-1)/2, 0, 0 };
+    DTYPE_OUT maximumValue = (DTYPE_OUT)READ_IMAGE_3D(src,sampler,coord).x;
+    float aSquared = e.x * e.x;
+    float bSquared = e.y * e.y;
+
+    for (int x = -e.x; x <= e.x; x++) {
+        float xSquared = x * x;
+        for (int y = -e.y; y <= e.y; y++) {
+            float ySquared = y * y;
+            if (xSquared / aSquared + ySquared / bSquared <= 1.0) {
+                DTYPE_OUT value = (DTYPE_OUT)READ_IMAGE_3D(src,sampler,coord+((int4){x,y,0,0})).x;
+                if (value > maximumValue) {
+                    maximumValue = value;
+                }
+            }
+        }
+    }
+
+  DTYPE_OUT res = maximumValue;
+  WRITE_IMAGE_3D(dst, coord, res);
+}
+
+
+__kernel void maximum_image2d
+(
+  DTYPE_IMAGE_OUT_2D dst, DTYPE_IMAGE_IN_2D src,
+  const int Nx, const int Ny
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1);
+  const int2 coord = (int2){i,j};
+    const int4   e = (int4)  { (Nx-1)/2, (Ny-1)/2, 0, 0 };
+
+    DTYPE_OUT maximumValue = (DTYPE_OUT)READ_IMAGE_2D(src,sampler,coord).x;
+    float aSquared = e.x * e.x;
+    float bSquared = e.y * e.y;
+
+    int count = 0;
+
+    for (int x = -e.x; x <= e.x; x++) {
+        float xSquared = x * x;
+        for (int y = -e.y; y <= e.y; y++) {
+            float ySquared = y * y;
+            if (xSquared / aSquared + ySquared / bSquared <= 1.0) {
+                DTYPE_OUT value = (DTYPE_OUT)READ_IMAGE_2D(src,sampler,coord+((int2){x,y})).x;
+                if (value > maximumValue) {
+                    maximumValue = value;
+                }
+            }
+        }
+    }
+
+  DTYPE_OUT res = maximumValue;
+
+  WRITE_IMAGE_2D(dst, coord, res);
+}
+
+__kernel void maximum_image2d_ij
+(
+  DTYPE_IMAGE_OUT_2D dst, DTYPE_IMAGE_IN_2D src,
+  const int radius
+)
+{
+    const int i = get_global_id(0), j = get_global_id(1);
+    const int2 coord = (int2){i,j};
+
+    // centers
+    const int4   e = (int4)  { radius, radius, 0, 0 };
+
+    float rSquared = pow((float)radius, 2) + 1;
+
+    float maximumValue = (float)(READ_IMAGE_2D(src,sampler,coord).x);
+    for (int x = -e.x; x <= e.x; x++) {
+        float xSquared = x * x;
+        for (int y = -e.y; y <= e.y; y++) {
+            float ySquared = y * y;
+            if (xSquared + ySquared <= rSquared) {
+                float value = (float)(READ_IMAGE_2D(src,sampler,coord+((int2){x,y})).x);
+                if (value > maximumValue) {
+                    maximumValue = value;
+                }
+            }
+        }
+    }
+
+    DTYPE_OUT res = maximumValue;
+    WRITE_IMAGE_2D(dst, coord, res);
+}
+
+
+__kernel void maximum_image3d
+(
+  DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src,
+  const int Nx, const int Ny, const int Nz
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4){i,j,k,0};
+
+
+    const int4   e = (int4)  {(Nx-1)/2, (Ny-1)/2, (Nz-1)/2, 0 };
+    float maximumValue = (float)READ_IMAGE_3D(src,sampler,coord).x;
+    float aSquared = e.x * e.x;
+    float bSquared = e.y * e.y;
+    float cSquared = e.z * e.z;
+
+    for (int x = -e.x; x <= e.x; x++) {
+        float xSquared = x * x;
+        for (int y = -e.y; y <= e.y; y++) {
+            float ySquared = y * y;
+            for (int z = -e.z; z <= e.z; z++) {
+                float zSquared = z * z;
+                if (xSquared / aSquared + ySquared / bSquared + zSquared / cSquared <= 1.0) {
+
+                    int x1 = coord.x + x;
+                    int x2 = coord.y + y;
+                    int x3 = coord.z + z;
+                    const int4 pos = (int4){x1,x2,x3,0};
+                    float value_res = (float)READ_IMAGE_3D(src,sampler,pos).x;
+                    if (value_res > maximumValue) {
+                        maximumValue = value_res;
+                    }
+                }
+            }
+        }
+    }
+
+  DTYPE_OUT res = maximumValue;
+  WRITE_IMAGE_3D(dst, coord, res);
+}
+
+__kernel void mean_sep_image3d
+(
+  DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src,
+  const int dim, const int N, const float s
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4)(i,j,k,0);
+  const int4 dir   = (int4)(dim==0,dim==1,dim==2,0);
+
+  // center
+  const int   c = (N-1)/2;
+
+  float res = 0, count = 0;
+  for (int v = -c; v <= c; v++) {
+    res += (float)READ_IMAGE_3D(src,sampler,coord+v*dir).x;
+    count += 1;
+  }
+  res /= count;
+  WRITE_IMAGE_3D(dst,coord,(DTYPE_OUT)res);
+}
+
+
+__kernel void min_sep_image3d
+(
+  DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src,
+  const int dim, const int N, const float s
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4)(i,j,k,0);
+  const int4 dir   = (int4)(dim==0,dim==1,dim==2,0);
+
+  // center
+  const int   c = (N-1)/2;
+
+  float res = READ_IMAGE_3D(src,sampler,coord).x;
+  for (int v = -c; v <= c; v++) {
+    res = min(res, (float)READ_IMAGE_3D(src,sampler,coord+v*dir).x);
+  }
+  WRITE_IMAGE_3D(dst,coord,(DTYPE_OUT)res);
+}
+
+__kernel void max_sep_image3d
+(
+  DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src,
+  const int dim, const int N, const float s
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4)(i,j,k,0);
+  const int4 dir   = (int4)(dim==0,dim==1,dim==2,0);
+
+  // center
+  const int   c = (N-1)/2;
+
+  float res = READ_IMAGE_3D(src,sampler,coord).x;
+  for (int v = -c; v <= c; v++) {
+    res = max(res, (float)READ_IMAGE_3D(src,sampler,coord+v*dir).x);
+  }
+  WRITE_IMAGE_3D(dst,coord,(DTYPE_OUT)res);
+}
+
+
+__kernel void mean_sep_image2d
+(
+  DTYPE_IMAGE_OUT_2D dst, DTYPE_IMAGE_IN_2D src,
+  const int dim, const int N, const float s
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1);
+  const int2 coord = (int2)(i,j);
+  const int2 dir   = (int2)(dim==0,dim==1);
+
+  // center
+  const int   c = (N-1)/2;
+
+  float res = 0, count = 0;
+  for (int v = -c; v <= c; v++) {
+    res += (float)READ_IMAGE_2D(src,sampler,coord+v*dir).x;
+    count += 1;
+  }
+  res /= count;
+  WRITE_IMAGE_2D(dst,coord,(DTYPE_OUT)res);
+}
+
+__kernel void min_sep_image2d
+(
+  DTYPE_IMAGE_OUT_2D dst, DTYPE_IMAGE_IN_2D src,
+  const int dim, const int N, const float s
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1);
+  const int2 coord = (int2)(i,j);
+  const int2 dir   = (int2)(dim==0,dim==1);
+
+  // center
+  const int   c = (N-1)/2;
+
+  float res = (float)(READ_IMAGE_2D(src,sampler,coord).x);
+  for (int v = -c; v <= c; v++) {
+    if (v != 0) {
+      res = min(res, (float)(READ_IMAGE_2D(src,sampler,coord+v*dir).x));
+    }
+  }
+  WRITE_IMAGE_2D(dst,coord,(DTYPE_OUT)res);
+}
+
+
+__kernel void max_sep_image2d
+(
+  DTYPE_IMAGE_OUT_2D dst, DTYPE_IMAGE_IN_2D src,
+  const int dim, const int N, const float s
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1);
+  const int2 coord = (int2)(i,j);
+  const int2 dir   = (int2)(dim==0,dim==1);
+
+  // center
+  const int   c = (N-1)/2;
+
+  float res = (float)READ_IMAGE_2D(src,sampler,coord).x;
+  for (int v = -c; v <= c; v++) {
+    if (v != 0) {
+      res = max(res, (float)(READ_IMAGE_2D(src,sampler,coord+v*dir).x));
+    }
+  }
+  WRITE_IMAGE_2D(dst,coord,(DTYPE_OUT)res);
+}
+

--- a/src/main/java/clearcl/ocllib/kernels/flip.cl
+++ b/src/main/java/clearcl/ocllib/kernels/flip.cl
@@ -1,0 +1,49 @@
+
+__kernel void flip_3d (    DTYPE_IMAGE_IN_3D  src,
+                           DTYPE_IMAGE_OUT_3D  dst,
+                           const          int        flipx,
+                           const          int        flipy,
+                           const          int        flipz
+                     )
+{
+  const sampler_t intsampler  = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_NONE | CLK_FILTER_NEAREST;
+
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int width = get_global_size(0);
+  const int height = get_global_size(1);
+  const int depth = get_global_size(2);
+
+  const int4 pos = (int4)(flipx?(width-1-x):x,
+                          flipy?(height-1-y):y,
+                          flipz?(depth-1-z):z,0);
+
+  const DTYPE_IN value = READ_IMAGE_3D(src, intsampler, pos).x;
+
+  WRITE_IMAGE_3D (dst, (int4)(x,y,z,0), (DTYPE_OUT)value);
+}
+
+
+__kernel void flip_2d (    DTYPE_IMAGE_IN_2D  src,
+                           DTYPE_IMAGE_OUT_2D  dst,
+                           const          int        flipx,
+                           const          int        flipy
+                       )
+{
+  const sampler_t intsampler  = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_NONE | CLK_FILTER_NEAREST;
+
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int width = get_global_size(0);
+  const int height = get_global_size(1);
+
+  const int2 pos = (int2)(flipx?(width-1-x):x,
+                          flipy?(height-1-y):y);
+
+  const DTYPE_IN value = READ_IMAGE_2D(src, intsampler, pos).x;
+
+  WRITE_IMAGE_2D (dst, (int2)(x,y), (DTYPE_OUT)value);
+}

--- a/src/main/java/clearcl/ocllib/kernels/histogram.cl
+++ b/src/main/java/clearcl/ocllib/kernels/histogram.cl
@@ -1,0 +1,92 @@
+// adapted code from
+// https://github.com/bgaster/opencl-book-samples/blob/master/src/Chapter_14/histogram/histogram_image.cl
+//
+// It was published unter BSD license according to
+// https://code.google.com/archive/p/opencl-book-samples/
+//
+// Book:      OpenCL(R) Programming Guide
+// Authors:   Aaftab Munshi, Benedict Gaster, Timothy Mattson, James Fung, Dan Ginsburg
+// ISBN-10:   0-321-74964-2
+// ISBN-13:   978-0-321-74964-2
+// Publisher: Addison-Wesley Professional
+// URLs:      http://safari.informit.com/9780132488006/
+//            http://www.openclprogrammingguide.com
+//
+//
+//
+
+#pragma OPENCL EXTENSION cl_khr_local_int32_base_atomics : enable
+
+//
+// this kernel takes a RGBA 8-bit / channel input image and produces a partial histogram.
+// the kernel is executed over multiple work-groups.  for each work-group a partial histogram is generated
+// partial_histogram is an array of num_groups * (256 * 3 * 32-bits/entry) entries
+// we store 256 Red bins, followed by 256 Green bins and then the 256 Blue bins.
+//
+
+
+// Notes (haesleinhuepf)
+// * dst_histogram must be a cl_buffer. Otherwise, GET_IMAGE_WIDTH(dst_histogram) would be no constant and allocating
+//   arrays with dynamic lengths is prohibited.
+//
+//
+
+const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+kernel
+void histogram_image_2d(DTYPE_IMAGE_IN_2D src, DTYPE_IMAGE_OUT_3D dst_histogram, float minimum, float maximum, int step_size_x, int step_size_y)
+{
+    int     image_width = GET_IMAGE_WIDTH(src);
+    int     image_height = GET_IMAGE_HEIGHT(src);
+    int     y = get_global_id(0) * step_size_y;
+    float range = maximum - minimum;
+
+    uint tmp_histogram[GET_IMAGE_WIDTH(dst_histogram)];
+    for (int i = 0; i < GET_IMAGE_WIDTH(dst_histogram); i++) {
+        tmp_histogram[i] = 0;
+    }
+
+    for (int x = 0; x < image_width; x+= step_size_x) {
+        float clr = READ_IMAGE_2D(src, sampler, (int2)(x, y)).x;
+        uchar   indx_x;
+        indx_x = convert_uchar_sat( (clr - minimum) * (float)(GET_IMAGE_WIDTH(dst_histogram)) / range );
+        tmp_histogram[indx_x]++;
+    }
+
+    for (int idx = 0; idx < GET_IMAGE_WIDTH(dst_histogram); idx++) {
+        int4 pos = {idx, 0, y, 0};
+        WRITE_IMAGE_3D(dst_histogram, pos,(DTYPE_OUT)tmp_histogram[idx]);
+    }
+}
+
+kernel
+void histogram_image_3d(DTYPE_IMAGE_IN_3D src, DTYPE_IMAGE_OUT_3D dst_histogram, float minimum, float maximum, int step_size_x, int step_size_y, int step_size_z)
+{
+    int     image_width = GET_IMAGE_WIDTH(src);
+    int     image_height = GET_IMAGE_HEIGHT(src);
+    int     image_depth = GET_IMAGE_DEPTH(src);
+    int     y = get_global_id(0);
+    float range = maximum - minimum;
+
+    uint tmp_histogram[GET_IMAGE_WIDTH(dst_histogram)];
+    for (int i = 0; i < GET_IMAGE_WIDTH(dst_histogram); i++) {
+        tmp_histogram[i] = 0;
+    }
+
+    for (int z = 0; z < image_depth; z+= step_size_z) {
+        for (int x = 0; x < image_width; x+= step_size_x) {
+            float clr = READ_IMAGE_3D(src, sampler, (int4)(x, y, z, 0)).x;
+            uchar   indx_x;
+            indx_x = convert_uchar_sat( (clr - minimum) * (float)(GET_IMAGE_WIDTH(dst_histogram)) / range );
+            tmp_histogram[indx_x]++;
+        }
+    }
+
+    for (int idx = 0; idx < GET_IMAGE_WIDTH(dst_histogram); idx++) {
+        int4 pos = {idx, 0, y, 0};
+        WRITE_IMAGE_3D(dst_histogram, pos,(DTYPE_OUT)tmp_histogram[idx]);
+    }
+}
+
+
+

--- a/src/main/java/clearcl/ocllib/kernels/mask.cl
+++ b/src/main/java/clearcl/ocllib/kernels/mask.cl
@@ -1,0 +1,60 @@
+__constant sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+__kernel void mask_3d(DTYPE_IMAGE_IN_3D  src,
+                                 DTYPE_IMAGE_IN_3D  mask,
+                          DTYPE_IMAGE_OUT_3D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  DTYPE_OUT value = 0;
+  if (READ_IMAGE_3D(mask, sampler, pos).x != 0) {
+    value = READ_IMAGE_3D(src, sampler, pos).x;
+  }
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+
+__kernel void mask_2d(DTYPE_IMAGE_IN_2D  src,
+                                 DTYPE_IMAGE_IN_2D  mask,
+                          DTYPE_IMAGE_OUT_2D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int2 pos = (int2){x,y};
+
+  DTYPE_OUT value = 0;
+  if (READ_IMAGE_2D(mask, sampler, pos).x != 0) {
+    value = READ_IMAGE_2D(src, sampler, pos).x;
+  }
+
+  WRITE_IMAGE_2D (dst, pos, value);
+}
+
+
+__kernel void maskStackWithPlane(DTYPE_IMAGE_IN_3D  src,
+                                 DTYPE_IMAGE_IN_2D  mask,
+                         DTYPE_IMAGE_OUT_3D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos3d = (int4){x,y,z,0};
+  const int2 pos2d = (int2){x,y};
+
+  DTYPE_OUT value = 0;
+  if (READ_IMAGE_2D(mask, sampler, pos2d).x != 0) {
+    value = READ_IMAGE_3D(src, sampler, pos3d).x;
+  }
+
+  WRITE_IMAGE_3D (dst, pos3d, value);
+}

--- a/src/main/java/clearcl/ocllib/kernels/math.cl
+++ b/src/main/java/clearcl/ocllib/kernels/math.cl
@@ -1,0 +1,476 @@
+__constant sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+__kernel void multiplyPixelwise_3d(DTYPE_IMAGE_IN_3D  src,
+                                   DTYPE_IMAGE_IN_3D src1,
+                          DTYPE_IMAGE_OUT_3D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  const DTYPE_OUT value = READ_IMAGE_3D(src, sampler, pos).x * READ_IMAGE_3D(src1, sampler, pos).x;
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+__kernel void multiplyPixelwise_2d(DTYPE_IMAGE_IN_2D  src,
+                                 DTYPE_IMAGE_IN_2D  src1,
+                          DTYPE_IMAGE_OUT_2D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int2 pos = (int2){x,y};
+
+  const DTYPE_OUT value = READ_IMAGE_2D(src, sampler, pos).x * READ_IMAGE_2D(src1, sampler, pos).x;
+
+  WRITE_IMAGE_2D (dst, pos, value);
+}
+
+__kernel void dividePixelwise_3d(DTYPE_IMAGE_IN_3D  src,
+                                 DTYPE_IMAGE_IN_3D  src1,
+                          DTYPE_IMAGE_OUT_3D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  const DTYPE_OUT value = READ_IMAGE_3D(src, sampler, pos).x / READ_IMAGE_3D(src1, sampler, pos).x;
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+__kernel void dividePixelwise_2d(DTYPE_IMAGE_IN_2D  src,
+                                 DTYPE_IMAGE_IN_2D  src1,
+                          DTYPE_IMAGE_OUT_2D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int2 pos = (int2){x,y};
+
+  const DTYPE_OUT value = READ_IMAGE_2D(src, sampler, pos).x / READ_IMAGE_2D(src1, sampler, pos).x;
+
+  WRITE_IMAGE_2D (dst, pos, value);
+}
+
+__kernel void multiplyStackWithPlanePixelwise(DTYPE_IMAGE_IN_3D  src,
+                                 DTYPE_IMAGE_IN_2D  src1,
+                          DTYPE_IMAGE_OUT_3D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos3d = (int4){x,y,z,0};
+  const int2 pos2d = (int2){x,y};
+
+  const DTYPE_OUT value = READ_IMAGE_3D(src, sampler, pos3d).x * READ_IMAGE_2D(src1, sampler, pos2d).x;
+
+  WRITE_IMAGE_3D (dst, pos3d, value);
+}
+
+__kernel void multiplySliceBySliceWithScalars(DTYPE_IMAGE_IN_3D  src,
+                                 __constant    float*  scalars,
+                          DTYPE_IMAGE_OUT_3D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos3d = (int4){x,y,z,0};
+
+  const DTYPE_OUT value = READ_IMAGE_3D(src, sampler, pos3d).x * scalars[z];
+
+  WRITE_IMAGE_3D (dst, pos3d, value);
+}
+
+
+__kernel void addPixelwise_3d(DTYPE_IMAGE_IN_3D  src,
+                                 DTYPE_IMAGE_IN_3D  src1,
+                          DTYPE_IMAGE_OUT_3D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  const DTYPE_OUT value = READ_IMAGE_3D(src, sampler, pos).x + READ_IMAGE_3D(src1, sampler, pos).x;
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+__kernel void addPixelwise_2d(DTYPE_IMAGE_IN_2D  src,
+                                 DTYPE_IMAGE_IN_2D  src1,
+                          DTYPE_IMAGE_OUT_2D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int2 pos = (int2){x,y};
+
+  const DTYPE_OUT value = READ_IMAGE_2D(src, sampler, pos).x + READ_IMAGE_2D(src1, sampler, pos).x;
+
+  WRITE_IMAGE_2D (dst, pos, value);
+}
+
+__kernel void addWeightedPixelwise_3d(DTYPE_IMAGE_IN_3D  src,
+                                 DTYPE_IMAGE_IN_3D  src1,
+                                 float factor,
+                                 float factor1,
+                          DTYPE_IMAGE_OUT_3D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  const DTYPE_OUT value = READ_IMAGE_3D(src, sampler, pos).x * factor + READ_IMAGE_3D(src1, sampler, pos).x * factor1;
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+
+__kernel void addWeightedPixelwise_2d(DTYPE_IMAGE_IN_2D  src,
+                                 DTYPE_IMAGE_IN_2D  src1,
+                                 float factor,
+                                 float factor1,
+                          DTYPE_IMAGE_OUT_2D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int2 pos = (int2){x,y};
+
+  const DTYPE_OUT value = READ_IMAGE_2D(src, sampler, pos).x * factor + READ_IMAGE_2D(src1, sampler, pos).x * factor1;
+
+  WRITE_IMAGE_2D (dst, pos, value);
+}
+
+
+__kernel void addScalar_3d(DTYPE_IMAGE_IN_3D  src,
+                                 float scalar,
+                          DTYPE_IMAGE_OUT_3D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  const DTYPE_OUT value = READ_IMAGE_3D(src, sampler, pos).x + scalar;
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+
+__kernel void addScalar_2d(DTYPE_IMAGE_IN_2D  src,
+                                 float scalar,
+                          DTYPE_IMAGE_OUT_2D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int2 pos = (int2){x,y};
+
+  const DTYPE_OUT value = READ_IMAGE_2D(src, sampler, pos).x + scalar;
+
+  WRITE_IMAGE_2D (dst, pos, value);
+}
+
+
+__kernel void multiplyScalar_3d(DTYPE_IMAGE_IN_3D  src,
+                                 float scalar,
+                          DTYPE_IMAGE_OUT_3D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  const DTYPE_OUT value = READ_IMAGE_3D(src, sampler, pos).x * scalar;
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+
+__kernel void multiplyScalar_2d(DTYPE_IMAGE_IN_2D  src,
+                                 float scalar,
+                          DTYPE_IMAGE_OUT_2D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int2 pos = (int2){x,y};
+
+  const DTYPE_OUT value = READ_IMAGE_2D(src, sampler, pos).x * scalar;
+
+  WRITE_IMAGE_2D (dst, pos, value);
+}
+
+
+
+__kernel void absolute_3d(DTYPE_IMAGE_IN_3D  src,
+                          DTYPE_IMAGE_OUT_3D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  DTYPE_OUT value = READ_IMAGE_3D(src, sampler, pos).x;
+  if ( value < 0 ) {
+    value = -1 * value;
+  }
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+
+__kernel void absolute_2d(DTYPE_IMAGE_IN_2D  src,
+                          DTYPE_IMAGE_OUT_2D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int2 pos = (int2){x,y};
+
+  DTYPE_OUT value = READ_IMAGE_2D(src, sampler, pos).x;
+  if ( value < 0 ) {
+    value = -1 * value;
+  }
+
+  WRITE_IMAGE_2D (dst, pos, value);
+}
+
+__kernel void maxPixelwise_3d(DTYPE_IMAGE_IN_3D src,
+                              DTYPE_IMAGE_IN_3D src1,
+                              DTYPE_IMAGE_OUT_3D dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  const DTYPE_IN input = READ_IMAGE_3D(src, sampler, pos).x;
+  const DTYPE_IN input1 = READ_IMAGE_3D(src1, sampler, pos).x;
+
+  const DTYPE_OUT value = max(input, input1);
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+__kernel void maxPixelwise_2d(DTYPE_IMAGE_IN_2D  src,
+                              DTYPE_IMAGE_IN_2D  src1,
+                              DTYPE_IMAGE_OUT_2D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int2 pos = (int2){x,y};
+
+  const DTYPE_IN input = READ_IMAGE_2D(src, sampler, pos).x;
+  const DTYPE_IN input1 = READ_IMAGE_2D(src1, sampler, pos).x;
+
+  const DTYPE_OUT value = max(input, input1);
+
+  WRITE_IMAGE_2D (dst, pos, value);
+}
+
+
+__kernel void minPixelwise_3d(DTYPE_IMAGE_IN_3D src,
+                              DTYPE_IMAGE_IN_3D src1,
+                              DTYPE_IMAGE_OUT_3D dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  const DTYPE_IN input = READ_IMAGE_3D(src, sampler, pos).x;
+  const DTYPE_IN input1 = READ_IMAGE_3D(src1, sampler, pos).x;
+
+  const DTYPE_OUT value = min(input, input1);
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+__kernel void minPixelwise_2d(DTYPE_IMAGE_IN_2D  src,
+                              DTYPE_IMAGE_IN_2D  src1,
+                              DTYPE_IMAGE_OUT_2D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int2 pos = (int2){x,y};
+
+  const DTYPE_IN input = READ_IMAGE_2D(src, sampler, pos).x;
+  const DTYPE_IN input1 = READ_IMAGE_2D(src1, sampler, pos).x;
+
+  const DTYPE_OUT value = min(input, input1);
+
+  WRITE_IMAGE_2D (dst, pos, value);
+}
+
+__kernel void maxPixelwiseScalar_3d(DTYPE_IMAGE_IN_3D src,
+                              float valueB,
+                              DTYPE_IMAGE_OUT_3D dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  const DTYPE_IN input = READ_IMAGE_3D(src, sampler, pos).x;
+  const DTYPE_IN input1 = valueB;
+
+  const DTYPE_OUT value = max(input, input1);
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+__kernel void maxPixelwiseScalar_2d(DTYPE_IMAGE_IN_2D  src,
+                              float valueB,
+                              DTYPE_IMAGE_OUT_2D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int2 pos = (int2){x,y};
+
+  const DTYPE_IN input = READ_IMAGE_2D(src, sampler, pos).x;
+  const DTYPE_IN input1 = valueB;
+
+  const DTYPE_OUT value = max(input, input1);
+
+  WRITE_IMAGE_2D (dst, pos, value);
+}
+
+
+__kernel void minPixelwiseScalar_3d(DTYPE_IMAGE_IN_3D src,
+                              float valueB,
+                              DTYPE_IMAGE_OUT_3D dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  const DTYPE_IN input = READ_IMAGE_3D(src, sampler, pos).x;
+  const DTYPE_IN input1 = valueB;
+
+  const DTYPE_OUT value = min(input, input1);
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+__kernel void minPixelwiseScalar_2d(DTYPE_IMAGE_IN_2D  src,
+                              float  valueB,
+                              DTYPE_IMAGE_OUT_2D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int2 pos = (int2){x,y};
+
+  const DTYPE_IN input = READ_IMAGE_2D(src, sampler, pos).x;
+  const DTYPE_IN input1 = valueB;
+
+  const DTYPE_OUT value = min(input, input1);
+
+  WRITE_IMAGE_2D (dst, pos, value);
+}
+
+
+
+__kernel void power_2d(DTYPE_IMAGE_IN_2D  src,
+                              DTYPE_IMAGE_OUT_2D  dst,
+                              float exponent
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int2 pos = (int2){x,y};
+
+  const DTYPE_IN input = READ_IMAGE_2D(src, sampler, pos).x;
+
+  const DTYPE_OUT value = pow(input, exponent);
+
+  WRITE_IMAGE_2D (dst, pos, value);
+}
+
+
+__kernel void power_3d(DTYPE_IMAGE_IN_3D src,
+                              DTYPE_IMAGE_OUT_3D dst,
+                              float exponent
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  const DTYPE_IN input = READ_IMAGE_3D(src, sampler, pos).x;
+
+  const DTYPE_OUT value = pow(input, exponent);
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+__kernel void multiply_pixelwise_with_coordinate_3d(DTYPE_IMAGE_IN_3D  src,
+                          DTYPE_IMAGE_OUT_3D  dst,
+                          int dimension
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  const DTYPE_OUT value = READ_IMAGE_3D(src, sampler, pos).x * get_global_id(dimension);
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+
+
+

--- a/src/main/java/clearcl/ocllib/kernels/neighbors.cl
+++ b/src/main/java/clearcl/ocllib/kernels/neighbors.cl
@@ -1,0 +1,95 @@
+__constant sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+
+__kernel void gradientX_2d
+(
+  DTYPE_IMAGE_OUT_2D dst, DTYPE_IMAGE_IN_2D src
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1);
+  const int2 coord = (int2){i,j};
+  const int2 coordA = (int2){i-1,j};
+  const int2 coordB = (int2){i+1,j};
+
+  DTYPE_OUT valueA = (DTYPE_OUT)READ_IMAGE_2D(src, sampler, coordA).x;
+  DTYPE_OUT valueB = (DTYPE_OUT)READ_IMAGE_2D(src, sampler, coordB).x;
+  DTYPE_OUT res = valueB - valueA;
+
+  WRITE_IMAGE_2D(dst, coord, res);
+}
+
+
+__kernel void gradientY_2d
+(
+  DTYPE_IMAGE_OUT_2D dst, DTYPE_IMAGE_IN_2D src
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1);
+  const int2 coord = (int2){i,j};
+  const int2 coordA = (int2){i,j-1};
+  const int2 coordB = (int2){i,j+1};
+
+  DTYPE_OUT valueA = (DTYPE_OUT)READ_IMAGE_2D(src, sampler, coordA).x;
+  DTYPE_OUT valueB = (DTYPE_OUT)READ_IMAGE_2D(src, sampler, coordB).x;
+  DTYPE_OUT res = valueB - valueA;
+
+  WRITE_IMAGE_2D(dst, coord, res);
+}
+
+__kernel void gradientX_3d
+(
+  DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src
+)
+{
+  const int i = get_global_id(0);
+  const int j = get_global_id(1);
+  const int k = get_global_id(2);
+  const int4 coord  = (int4){i, j, k, 0};
+  const int4 coordA = (int4){i-1, j, k, 0};
+  const int4 coordB = (int4){i+1, j, k, 0};
+
+  DTYPE_OUT valueA = (DTYPE_OUT)READ_IMAGE_3D(src, sampler, coordA).x;
+  DTYPE_OUT valueB = (DTYPE_OUT)READ_IMAGE_3D(src, sampler, coordB).x;
+  DTYPE_OUT res = valueB - valueA;
+
+  WRITE_IMAGE_3D(dst, coord, res);
+}
+
+__kernel void gradientY_3d
+(
+  DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src
+)
+{
+  const int i = get_global_id(0);
+  const int j = get_global_id(1);
+  const int k = get_global_id(2);
+  const int4 coord  = (int4){i, j, k, 0};
+  const int4 coordA = (int4){i, j-1, k, 0};
+  const int4 coordB = (int4){i, j+1, k, 0};
+
+  DTYPE_OUT valueA = (DTYPE_OUT)READ_IMAGE_3D(src, sampler, coordA).x;
+  DTYPE_OUT valueB = (DTYPE_OUT)READ_IMAGE_3D(src, sampler, coordB).x;
+  DTYPE_OUT res = valueB - valueA;
+
+  WRITE_IMAGE_3D(dst, coord, res);
+}
+
+__kernel void gradientZ_3d
+(
+  DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src
+)
+{
+  const int i = get_global_id(0);
+  const int j = get_global_id(1);
+  const int k = get_global_id(2);
+  const int4 coord  = (int4){i, j, k, 0};
+  const int4 coordA = (int4){i, j, k-1, 0};
+  const int4 coordB = (int4){i, j, k+1, 0};
+
+  DTYPE_OUT valueA = (DTYPE_OUT)READ_IMAGE_3D(src, sampler, coordA).x;
+  DTYPE_OUT valueB = (DTYPE_OUT)READ_IMAGE_3D(src, sampler, coordB).x;
+  DTYPE_OUT res = valueB - valueA;
+
+  WRITE_IMAGE_3D(dst, coord, res);
+}
+

--- a/src/main/java/clearcl/ocllib/kernels/projections.cl
+++ b/src/main/java/clearcl/ocllib/kernels/projections.cl
@@ -1,0 +1,178 @@
+__kernel void sum_project_3d_2d(
+    DTYPE_IMAGE_OUT_2D dst,
+    DTYPE_IMAGE_IN_3D src
+) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  DTYPE_IN sum = 0;
+  for(int z = 0; z < GET_IMAGE_IN_DEPTH(src); z++)
+  {
+    sum = sum + READ_IMAGE_3D(src,sampler,(int4)(x,y,z,0)).x;
+  }
+  WRITE_IMAGE_2D(dst,(int2)(x,y),(DTYPE_OUT)sum);
+}
+
+__kernel void mean_project_3d_2d(
+    DTYPE_IMAGE_OUT_2D dst,
+    DTYPE_IMAGE_IN_3D src
+) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  DTYPE_IN sum = 0;
+  int count = 0;
+  for(int z = 0; z < GET_IMAGE_IN_DEPTH(src); z++)
+  {
+    sum = sum + READ_IMAGE_3D(src,sampler,(int4)(x,y,z,0)).x;
+    count++;
+  }
+  WRITE_IMAGE_2D(dst,(int2)(x,y),(DTYPE_OUT)(sum / count));
+}
+
+__kernel void arg_max_project_3d_2d(
+    DTYPE_IMAGE_OUT_2D dst_max,
+    DTYPE_IMAGE_OUT_2D dst_arg,
+    DTYPE_IMAGE_IN_3D src
+) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  DTYPE_IN max = 0;
+  int max_pos = 0;
+  for(int z = 0; z < GET_IMAGE_IN_DEPTH(src); z++)
+  {
+    DTYPE_IN value = READ_IMAGE_3D(src,sampler,(int4)(x,y,z,0)).x;
+    if (value > max || z == 0) {
+      max = value;
+      max_pos = z;
+    }
+  }
+  WRITE_IMAGE_2D(dst_max,(int2)(x,y),(DTYPE_OUT)max);
+  WRITE_IMAGE_2D(dst_arg,(int2)(x,y),(DTYPE_OUT)max_pos);
+}
+
+__kernel void max_project_3d_2d(
+    DTYPE_IMAGE_OUT_2D dst_max,
+    DTYPE_IMAGE_IN_3D src
+) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  DTYPE_IN max = 0;
+  for(int z = 0; z < GET_IMAGE_IN_DEPTH(src); z++)
+  {
+    DTYPE_IN value = READ_IMAGE_3D(src,sampler,(int4)(x,y,z,0)).x;
+    if (value > max || z == 0) {
+      max = value;
+    }
+  }
+  WRITE_IMAGE_2D(dst_max,(int2)(x,y),(DTYPE_OUT)max);
+}
+
+__kernel void min_project_3d_2d(
+    DTYPE_IMAGE_OUT_2D dst_min,
+    DTYPE_IMAGE_IN_3D src
+) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  DTYPE_IN min = 0;
+  for(int z = 0; z < GET_IMAGE_IN_DEPTH(src); z++)
+  {
+    DTYPE_IN value = READ_IMAGE_3D(src,sampler,(int4)(x,y,z,0)).x;
+    if (value < min || z == 0) {
+      min = value;
+    }
+  }
+  WRITE_IMAGE_2D(dst_min,(int2)(x,y),(DTYPE_OUT)min);
+}
+
+
+__kernel void max_project_dim_select_3d_2d(
+    DTYPE_IMAGE_OUT_2D dst_max,
+    DTYPE_IMAGE_IN_3D src,
+    int projection_x,
+    int projection_y,
+    int projection_dim
+) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  int4 sourcePos = (int4)(0,0,0,0);
+  int2 targetPos = (int2)(get_global_id(0), get_global_id(1));
+
+  if (projection_x == 0) {
+    sourcePos.x = get_global_id(0);
+  } else if (projection_x == 1) {
+    sourcePos.y = get_global_id(0);
+  } else {
+    sourcePos.z = get_global_id(0);
+  }
+  if (projection_y == 0) {
+    sourcePos.x = get_global_id(1);
+  } else if (projection_y == 1) {
+    sourcePos.y = get_global_id(1);
+  } else {
+    sourcePos.z = get_global_id(1);
+  }
+
+
+  int max_d = 0;
+  if (projection_dim == 0) {
+    max_d = GET_IMAGE_IN_WIDTH(src);
+  } else if (projection_dim == 1) {
+    max_d = GET_IMAGE_IN_HEIGHT(src);
+  } else {
+    max_d = GET_IMAGE_IN_DEPTH(src);
+  }
+
+  DTYPE_IN max = 0;
+  for(int d = 0; d < max_d; d++)
+  {
+    if (projection_dim == 0) {
+      sourcePos.x = d;
+    } else if (projection_dim == 0) {
+      sourcePos.y = d;
+    } else {
+      sourcePos.z = d;
+    }
+    DTYPE_IN value = READ_IMAGE_3D(src,sampler, sourcePos).x;
+    if (value > max || d == 0) {
+      max = value;
+    }
+  }
+  WRITE_IMAGE_2D(dst_max,targetPos,(DTYPE_OUT)max);
+}
+
+
+__kernel void radialProjection3d(
+    DTYPE_IMAGE_OUT_3D dst,
+    DTYPE_IMAGE_IN_3D src,
+    float deltaAngle
+) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const float imageHalfWidth = GET_IMAGE_IN_WIDTH(src) / 2;
+  const float imageHalfHeight = GET_IMAGE_IN_HEIGHT(src) / 2;
+
+  float angleInRad = ((float)z) * deltaAngle / 180.0 * M_PI;
+  //float maxRadius = sqrt(pow(imageHalfWidth, 2.0f) + pow(imageHalfHeight, 2.0f));
+  float radius = x;
+
+  const int sx = (int)(imageHalfWidth + sin(angleInRad) * radius);
+  const int sy = (int)(imageHalfHeight + cos(angleInRad) * radius);
+  const int sz = y;
+
+  DTYPE_IN value = READ_IMAGE_3D(src,sampler,(int4)(sx,sy,sz,0)).x;
+  WRITE_IMAGE_3D(dst,(int4)(x,y,z,0),(DTYPE_OUT)value);
+}
+

--- a/src/main/java/clearcl/ocllib/kernels/reslicing.cl
+++ b/src/main/java/clearcl/ocllib/kernels/reslicing.cl
@@ -1,0 +1,65 @@
+__constant sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+
+
+__kernel void reslice_bottom_3d(DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int sx = get_global_id(0);
+  const int sy = get_global_id(2);
+  const int sz = get_global_id(1);
+
+  const int dx = get_global_id(0);
+  const int dy = get_global_id(1);
+  const int dz = get_global_size(2) - get_global_id(2) - 1;
+
+  const DTYPE_IN out = READ_IMAGE_3D(src,sampler,(int4)(sx,sy,sz,0)).x;
+  WRITE_IMAGE_3D(dst,(int4)(dx,dy,dz,0),(DTYPE_OUT)out);
+}
+
+__kernel void reslice_left_3d(DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int sx = get_global_id(2);
+  const int sy = get_global_id(0);
+  const int sz = get_global_id(1);
+
+  const int dx = get_global_id(0);
+  const int dy = get_global_id(1);
+  const int dz = get_global_id(2);
+
+  const DTYPE_IN out = READ_IMAGE_3D(src,sampler,(int4)(sx,sy,sz,0)).x;
+  WRITE_IMAGE_3D(dst,(int4)(dx,dy,dz,0),(DTYPE_OUT)out);
+}
+
+
+__kernel void reslice_right_3d(DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int sx = get_global_id(2);
+  const int sy = get_global_id(0);
+  const int sz = get_global_id(1);
+
+  const int dx = get_global_id(0);
+  const int dy = get_global_id(1);
+  const int dz = get_global_size(2) - get_global_id(2) - 1;
+
+  const DTYPE_IN out = READ_IMAGE_3D(src,sampler,(int4)(sx,sy,sz,0)).x;
+  WRITE_IMAGE_3D(dst,(int4)(dx,dy,dz,0),(DTYPE_OUT)out);
+}
+
+
+__kernel void reslice_top_3d(DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int sx = get_global_id(0);
+  const int sy = get_global_id(2);
+  const int sz = get_global_id(1);
+
+  const int dx = get_global_id(0);
+  const int dy = get_global_id(1);
+  const int dz = get_global_id(2);
+
+  const DTYPE_IN out = READ_IMAGE_3D(src,sampler,(int4)(sx,sy,sz,0)).x;
+  WRITE_IMAGE_3D(dst,(int4)(dx,dy,dz,0),(DTYPE_OUT)out);
+}

--- a/src/main/java/clearcl/ocllib/kernels/rotate.cl
+++ b/src/main/java/clearcl/ocllib/kernels/rotate.cl
@@ -1,0 +1,60 @@
+__constant sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+
+
+__kernel void rotate_left_3d(DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int sx = get_global_size(1) - get_global_id(1) - 1;
+  const int sy = get_global_id(0);
+  const int sz = get_global_id(2);
+
+  const int dx = get_global_id(0);
+  const int dy = get_global_id(1);
+  const int dz = get_global_id(2);
+
+  const DTYPE_IN out = READ_IMAGE_3D(src,sampler,(int4)(sx,sy,sz,0)).x;
+  WRITE_IMAGE_3D(dst,(int4)(dx,dy,dz,0),(DTYPE_OUT)out);
+}
+
+__kernel void rotate_right_3d(DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int sx = get_global_id(1);
+  const int sy = get_global_size(0) - get_global_id(0) - 1;
+  const int sz = get_global_id(2);
+
+  const int dx = get_global_id(0);
+  const int dy = get_global_id(1);
+  const int dz = get_global_id(2);
+
+  const DTYPE_IN out = READ_IMAGE_3D(src,sampler,(int4)(sx,sy,sz,0)).x;
+  WRITE_IMAGE_3D(dst,(int4)(dx,dy,dz,0),(DTYPE_OUT)out);
+}
+
+__kernel void rotate_left_2d(DTYPE_IMAGE_OUT_2D dst, DTYPE_IMAGE_IN_2D src) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int sx = get_global_size(1) - get_global_id(1) - 1;
+  const int sy = get_global_id(0);
+
+  const int dx = get_global_id(0);
+  const int dy = get_global_id(1);
+
+  const DTYPE_IN out = READ_IMAGE_2D(src,sampler,(int2)(sx,sy)).x;
+  WRITE_IMAGE_2D(dst,(int2)(dx,dy),(DTYPE_OUT)out);
+}
+
+
+__kernel void rotate_right_2d(DTYPE_IMAGE_OUT_2D dst, DTYPE_IMAGE_IN_2D src) {
+  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+  const int sx = get_global_id(1);
+  const int sy = get_global_size(0) - get_global_id(0) - 1;
+
+  const int dx = get_global_id(0);
+  const int dy = get_global_id(1);
+
+  const DTYPE_IN out = READ_IMAGE_2D(src,sampler,(int2)(sx,sy)).x;
+  WRITE_IMAGE_2D(dst,(int2)(dx,dy),(DTYPE_OUT)out);
+}

--- a/src/main/java/clearcl/ocllib/kernels/set.cl
+++ b/src/main/java/clearcl/ocllib/kernels/set.cl
@@ -1,0 +1,22 @@
+
+__kernel void set_3d(DTYPE_IMAGE_OUT_3D  dst,
+                  float value
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  WRITE_IMAGE_3D (dst, (int4)(x,y,z,0), (DTYPE_OUT)value);
+}
+
+
+__kernel void set_2d(DTYPE_IMAGE_OUT_2D  dst,
+                  float value
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  WRITE_IMAGE_2D (dst, (int2)(x,y), (DTYPE_OUT)value);
+}

--- a/src/main/java/clearcl/ocllib/kernels/stacksplitting.cl
+++ b/src/main/java/clearcl/ocllib/kernels/stacksplitting.cl
@@ -1,0 +1,220 @@
+__constant sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+
+__kernel void split_2_stacks(DTYPE_IMAGE_IN_3D src, DTYPE_IMAGE_OUT_3D dst0, DTYPE_IMAGE_OUT_3D dst1){
+
+   const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+
+   WRITE_IMAGE_3D(dst0,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(const int4)(i,j,2*k,0)).x);
+   WRITE_IMAGE_3D(dst1,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,2*k+1,0)).x);
+}
+
+__kernel void split_3_stacks(DTYPE_IMAGE_IN_3D src, DTYPE_IMAGE_OUT_3D dst0, DTYPE_IMAGE_OUT_3D dst1, DTYPE_IMAGE_OUT_3D dst2){
+
+   const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+
+   WRITE_IMAGE_3D(dst0,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(const int4)(i,j,3*k,0)).x);
+   WRITE_IMAGE_3D(dst1,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,3*k+1,0)).x);
+   WRITE_IMAGE_3D(dst2,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,3*k+2,0)).x);
+}
+
+__kernel void split_4_stacks(DTYPE_IMAGE_IN_3D src, DTYPE_IMAGE_OUT_3D dst0, DTYPE_IMAGE_OUT_3D dst1, DTYPE_IMAGE_OUT_3D dst2, DTYPE_IMAGE_OUT_3D dst3){
+
+   const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+
+   WRITE_IMAGE_3D(dst0,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(const int4)(i,j,4*k,0)).x);
+   WRITE_IMAGE_3D(dst1,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,4*k+1,0)).x);
+   WRITE_IMAGE_3D(dst2,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,4*k+2,0)).x);
+   WRITE_IMAGE_3D(dst3,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,4*k+3,0)).x);
+}
+
+__kernel void split_5_stacks(DTYPE_IMAGE_IN_3D src, DTYPE_IMAGE_OUT_3D dst0, DTYPE_IMAGE_OUT_3D dst1, DTYPE_IMAGE_OUT_3D dst2, DTYPE_IMAGE_OUT_3D dst3, DTYPE_IMAGE_OUT_3D dst4){
+
+   const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+
+   WRITE_IMAGE_3D(dst0,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(const int4)(i,j,5*k,0)).x);
+   WRITE_IMAGE_3D(dst1,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,5*k+1,0)).x);
+   WRITE_IMAGE_3D(dst2,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,5*k+2,0)).x);
+   WRITE_IMAGE_3D(dst3,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,5*k+3,0)).x);
+   WRITE_IMAGE_3D(dst4,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,5*k+4,0)).x);
+}
+
+
+__kernel void split_6_stacks(DTYPE_IMAGE_IN_3D src,
+                             DTYPE_IMAGE_OUT_3D dst0,
+                             DTYPE_IMAGE_OUT_3D dst1,
+                             DTYPE_IMAGE_OUT_3D dst2,
+                             DTYPE_IMAGE_OUT_3D dst3,
+                             DTYPE_IMAGE_OUT_3D dst4,
+                             DTYPE_IMAGE_OUT_3D dst5
+                         ){
+
+   const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+
+   WRITE_IMAGE_3D(dst0,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(const int4)(i,j,6*k,0)).x);
+   WRITE_IMAGE_3D(dst1,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,6*k+1,0)).x);
+   WRITE_IMAGE_3D(dst2,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,6*k+2,0)).x);
+   WRITE_IMAGE_3D(dst3,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,6*k+3,0)).x);
+   WRITE_IMAGE_3D(dst4,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,6*k+4,0)).x);
+   WRITE_IMAGE_3D(dst5,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,6*k+5,0)).x);
+}
+
+
+__kernel void split_7_stacks(DTYPE_IMAGE_IN_3D src,
+                             DTYPE_IMAGE_OUT_3D dst0,
+                             DTYPE_IMAGE_OUT_3D dst1,
+                             DTYPE_IMAGE_OUT_3D dst2,
+                             DTYPE_IMAGE_OUT_3D dst3,
+                             DTYPE_IMAGE_OUT_3D dst4,
+                             DTYPE_IMAGE_OUT_3D dst5,
+                             DTYPE_IMAGE_OUT_3D dst6
+                         ){
+
+   const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+
+   WRITE_IMAGE_3D(dst0,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(const int4)(i,j,7*k,0)).x);
+   WRITE_IMAGE_3D(dst1,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,7*k+1,0)).x);
+   WRITE_IMAGE_3D(dst2,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,7*k+2,0)).x);
+   WRITE_IMAGE_3D(dst3,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,7*k+3,0)).x);
+   WRITE_IMAGE_3D(dst4,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,7*k+4,0)).x);
+   WRITE_IMAGE_3D(dst5,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,7*k+5,0)).x);
+   WRITE_IMAGE_3D(dst6,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,7*k+6,0)).x);
+}
+
+__kernel void split_8_stacks(DTYPE_IMAGE_IN_3D src,
+                                 DTYPE_IMAGE_OUT_3D dst0,
+                                 DTYPE_IMAGE_OUT_3D dst1,
+                                 DTYPE_IMAGE_OUT_3D dst2,
+                                 DTYPE_IMAGE_OUT_3D dst3,
+                                 DTYPE_IMAGE_OUT_3D dst4,
+                                 DTYPE_IMAGE_OUT_3D dst5,
+                                 DTYPE_IMAGE_OUT_3D dst6,
+                                 DTYPE_IMAGE_OUT_3D dst7
+                             ){
+
+   const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+
+   WRITE_IMAGE_3D(dst0,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(const int4)(i,j,8*k,0)).x);
+   WRITE_IMAGE_3D(dst1,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,8*k+1,0)).x);
+   WRITE_IMAGE_3D(dst2,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,8*k+2,0)).x);
+   WRITE_IMAGE_3D(dst3,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,8*k+3,0)).x);
+   WRITE_IMAGE_3D(dst4,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,8*k+4,0)).x);
+   WRITE_IMAGE_3D(dst5,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,8*k+5,0)).x);
+   WRITE_IMAGE_3D(dst6,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,8*k+6,0)).x);
+   WRITE_IMAGE_3D(dst7,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,8*k+7,0)).x);
+}
+
+
+__kernel void split_9_stacks(DTYPE_IMAGE_IN_3D src,
+                                DTYPE_IMAGE_OUT_3D dst0,
+                                DTYPE_IMAGE_OUT_3D dst1,
+                                DTYPE_IMAGE_OUT_3D dst2,
+                                DTYPE_IMAGE_OUT_3D dst3,
+                                DTYPE_IMAGE_OUT_3D dst4,
+                                DTYPE_IMAGE_OUT_3D dst5,
+                                DTYPE_IMAGE_OUT_3D dst6,
+                                DTYPE_IMAGE_OUT_3D dst7,
+                                DTYPE_IMAGE_OUT_3D dst8
+                            ){
+
+   const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+
+   WRITE_IMAGE_3D(dst0,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(const int4)(i,j,9*k,0)).x);
+   WRITE_IMAGE_3D(dst1,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,9*k+1,0)).x);
+   WRITE_IMAGE_3D(dst2,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,9*k+2,0)).x);
+   WRITE_IMAGE_3D(dst3,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,9*k+3,0)).x);
+   WRITE_IMAGE_3D(dst4,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,9*k+4,0)).x);
+   WRITE_IMAGE_3D(dst5,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,9*k+5,0)).x);
+   WRITE_IMAGE_3D(dst6,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,9*k+6,0)).x);
+   WRITE_IMAGE_3D(dst7,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,9*k+7,0)).x);
+   WRITE_IMAGE_3D(dst8,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,9*k+8,0)).x);
+}
+
+__kernel void split_10_stacks(DTYPE_IMAGE_IN_3D src,
+                                DTYPE_IMAGE_OUT_3D dst0,
+                                DTYPE_IMAGE_OUT_3D dst1,
+                                DTYPE_IMAGE_OUT_3D dst2,
+                                DTYPE_IMAGE_OUT_3D dst3,
+                                DTYPE_IMAGE_OUT_3D dst4,
+                                DTYPE_IMAGE_OUT_3D dst5,
+                                DTYPE_IMAGE_OUT_3D dst6,
+                                DTYPE_IMAGE_OUT_3D dst7,
+                                DTYPE_IMAGE_OUT_3D dst8,
+                                DTYPE_IMAGE_OUT_3D dst9
+                            ){
+
+   const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+
+   WRITE_IMAGE_3D(dst0,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(const int4)(i,j,10*k,0)).x);
+   WRITE_IMAGE_3D(dst1,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,10*k+1,0)).x);
+   WRITE_IMAGE_3D(dst2,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,10*k+2,0)).x);
+   WRITE_IMAGE_3D(dst3,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,10*k+3,0)).x);
+   WRITE_IMAGE_3D(dst4,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,10*k+4,0)).x);
+   WRITE_IMAGE_3D(dst5,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,10*k+5,0)).x);
+   WRITE_IMAGE_3D(dst6,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,10*k+6,0)).x);
+   WRITE_IMAGE_3D(dst7,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,10*k+7,0)).x);
+   WRITE_IMAGE_3D(dst8,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,10*k+8,0)).x);
+   WRITE_IMAGE_3D(dst9,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,10*k+9,0)).x);
+}
+
+
+__kernel void split_11_stacks(DTYPE_IMAGE_IN_3D src,
+                                DTYPE_IMAGE_OUT_3D dst0,
+                                DTYPE_IMAGE_OUT_3D dst1,
+                                DTYPE_IMAGE_OUT_3D dst2,
+                                DTYPE_IMAGE_OUT_3D dst3,
+                                DTYPE_IMAGE_OUT_3D dst4,
+                                DTYPE_IMAGE_OUT_3D dst5,
+                                DTYPE_IMAGE_OUT_3D dst6,
+                                DTYPE_IMAGE_OUT_3D dst7,
+                                DTYPE_IMAGE_OUT_3D dst8,
+                                DTYPE_IMAGE_OUT_3D dst9,
+                                DTYPE_IMAGE_OUT_3D dst10
+                            ){
+
+   const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+
+   WRITE_IMAGE_3D(dst0,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(const int4)(i,j,11*k,0)).x);
+   WRITE_IMAGE_3D(dst1,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,11*k+1,0)).x);
+   WRITE_IMAGE_3D(dst2,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,11*k+2,0)).x);
+   WRITE_IMAGE_3D(dst3,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,11*k+3,0)).x);
+   WRITE_IMAGE_3D(dst4,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,11*k+4,0)).x);
+   WRITE_IMAGE_3D(dst5,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,11*k+5,0)).x);
+   WRITE_IMAGE_3D(dst6,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,11*k+6,0)).x);
+   WRITE_IMAGE_3D(dst7,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,11*k+7,0)).x);
+   WRITE_IMAGE_3D(dst8,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,11*k+8,0)).x);
+   WRITE_IMAGE_3D(dst9,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,11*k+9,0)).x);
+   WRITE_IMAGE_3D(dst10,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,11*k+10,0)).x);
+}
+
+
+__kernel void split_12_stacks(DTYPE_IMAGE_IN_3D src,
+                                DTYPE_IMAGE_OUT_3D dst0,
+                                DTYPE_IMAGE_OUT_3D dst1,
+                                DTYPE_IMAGE_OUT_3D dst2,
+                                DTYPE_IMAGE_OUT_3D dst3,
+                                DTYPE_IMAGE_OUT_3D dst4,
+                                DTYPE_IMAGE_OUT_3D dst5,
+                                DTYPE_IMAGE_OUT_3D dst6,
+                                DTYPE_IMAGE_OUT_3D dst7,
+                                DTYPE_IMAGE_OUT_3D dst8,
+                                DTYPE_IMAGE_OUT_3D dst9,
+                                DTYPE_IMAGE_OUT_3D dst10,
+                                DTYPE_IMAGE_OUT_3D dst11
+                            ){
+
+   const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+
+   WRITE_IMAGE_3D(dst0,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(const int4)(i,j,12*k,0)).x);
+   WRITE_IMAGE_3D(dst1,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,12*k+1,0)).x);
+   WRITE_IMAGE_3D(dst2,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,12*k+2,0)).x);
+   WRITE_IMAGE_3D(dst3,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,12*k+3,0)).x);
+   WRITE_IMAGE_3D(dst4,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,12*k+4,0)).x);
+   WRITE_IMAGE_3D(dst5,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,12*k+5,0)).x);
+   WRITE_IMAGE_3D(dst6,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,12*k+6,0)).x);
+   WRITE_IMAGE_3D(dst7,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,12*k+7,0)).x);
+   WRITE_IMAGE_3D(dst8,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,12*k+8,0)).x);
+   WRITE_IMAGE_3D(dst9,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,12*k+9,0)).x);
+   WRITE_IMAGE_3D(dst10,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,12*k+10,0)).x);
+   WRITE_IMAGE_3D(dst11,(int4)(i,j,k,0),(DTYPE_OUT)READ_IMAGE_3D(src,sampler,(int4)(i,j,12*k+11,0)).x);
+}

--- a/src/main/java/clearcl/ocllib/kernels/tenengradFusion.cl
+++ b/src/main/java/clearcl/ocllib/kernels/tenengradFusion.cl
@@ -1,0 +1,520 @@
+__constant sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+__constant float hx[] = {-1,-2,-1,-2,-4,-2,-1,-2,-1,0,0,0,0,0,0,0,0,0,1,2,1,2,4,2,1,2,1};
+__constant float hy[] = {-1,-2,-1,0,0,0,1,2,1,-2,-4,-2,0,0,0,2,4,2,-1,-2,-1,0,0,0,1,2,1};
+__constant float hz[] = {-1,0,1,-2,0,2,-1,0,1,-2,0,2,-4,0,4,-2,0,2,-1,0,1,-2,0,2,-1,0,1};
+
+
+inline float sobel_magnitude_squared(DTYPE_IMAGE_IN_3D src, const int i0, const int j0, const int k0) {
+  float Gx = 0.0f, Gy = 0.0f, Gz = 0.0f;
+  for (int i = 0; i < 3; ++i) for (int j = 0; j < 3; ++j) for (int k = 0; k < 3; ++k) {
+    const int dx = i-1, dy = j-1, dz = k-1;
+    const int ind = i + 3*j + 3*3*k;
+    const float pix = (float)READ_IMAGE_3D(src,sampler,(int4)(i0+dx,j0+dy,k0+dz,0)).x;
+    Gx += hx[ind]*pix;
+    Gy += hy[ind]*pix;
+    Gz += hz[ind]*pix;
+  }
+  return Gx*Gx + Gy*Gy + Gz*Gz;
+}
+
+
+__kernel void tenengrad_weight_unnormalized(DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src) {
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4)(i,j,k,0);
+  float w = sobel_magnitude_squared(src,i,j,k);
+  // w = w*w;
+  WRITE_IMAGE_3D(dst,coord,(DTYPE_OUT)w);
+}
+
+inline float sobel_magnitude_squared_slice_wise(DTYPE_IMAGE_IN_3D src, const int i0, const int j0, const int k0) {
+  float Gx = 0.0f, Gy = 0.0f;
+  for (int i = 0; i < 3; ++i) for (int j = 0; j < 3; ++j) for (int k = 0; k < 3; ++k) {
+    const int dx = i-1, dy = j-1, dz = k-1;
+    const int ind = i + 3*j + 3*3*k;
+    const float pix = (float)READ_IMAGE_3D(src,sampler,(int4)(i0+dx,j0+dy,k0+dz,0)).x;
+    Gx += hx[ind]*pix;
+    Gy += hy[ind]*pix;
+  }
+  return Gx*Gx + Gy*Gy;
+}
+
+
+__kernel void tenengrad_weight_unnormalized_slice_wise(DTYPE_IMAGE_OUT_3D dst, DTYPE_IMAGE_IN_3D src) {
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4)(i,j,k,0);
+  float w = sobel_magnitude_squared_slice_wise(src,i,j,k);
+  // w = w*w;
+  WRITE_IMAGE_3D(dst,coord,(DTYPE_OUT)w);
+}
+
+
+__kernel void tenengrad_fusion_with_provided_weights_2_images(
+  DTYPE_IMAGE_OUT_3D dst, const int factor,
+  DTYPE_IMAGE_IN_3D src0, DTYPE_IMAGE_IN_3D src1,
+  DTYPE_IMAGE_IN_3D weight0, DTYPE_IMAGE_IN_3D weight1
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4)(i,j,k,0);
+
+  const float4 coord_weight = (float4)((i+0.5f)/factor,(j+0.5f)/factor,k+0.5f,0);
+  const sampler_t sampler_weight = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_LINEAR;
+
+  float w0 = read_imagef(weight0,sampler_weight,coord_weight).x;
+  float w1 = read_imagef(weight1,sampler_weight,coord_weight).x;
+
+  const float wsum = w0 + w1 + 1e-30f; // add small epsilon to avoid wsum = 0
+  w0 /= wsum;
+  w1 /= wsum;
+
+  const float  v0 = (float)READ_IMAGE_3D(src0,sampler,coord).x;
+  const float  v1 = (float)READ_IMAGE_3D(src1,sampler,coord).x;
+  const float res = w0 * v0 + w1 * v1;
+
+  WRITE_IMAGE_3D(dst,coord,(DTYPE_OUT)res);
+}
+
+
+__kernel void tenengrad_fusion_with_provided_weights_3_images(
+  DTYPE_IMAGE_OUT_3D dst, const int factor,
+  DTYPE_IMAGE_IN_3D src0, DTYPE_IMAGE_IN_3D src1, DTYPE_IMAGE_IN_3D src2,
+  DTYPE_IMAGE_IN_3D weight0, DTYPE_IMAGE_IN_3D weight1, DTYPE_IMAGE_IN_3D weight2
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4)(i,j,k,0);
+
+  const float4 coord_weight = (float4)((i+0.5f)/factor,(j+0.5f)/factor,k+0.5f,0);
+  const sampler_t sampler_weight = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_LINEAR;
+
+  float w0 = read_imagef(weight0,sampler_weight,coord_weight).x;
+  float w1 = read_imagef(weight1,sampler_weight,coord_weight).x;
+  float w2 = read_imagef(weight2,sampler_weight,coord_weight).x;
+
+  const float wsum = w0 + w1 + w2 + 1e-30f; // add small epsilon to avoid wsum = 0
+  w0 /= wsum;
+  w1 /= wsum;
+  w2 /= wsum;
+
+  const float  v0 = (float)READ_IMAGE_3D(src0,sampler,coord).x;
+  const float  v1 = (float)READ_IMAGE_3D(src1,sampler,coord).x;
+  const float  v2 = (float)READ_IMAGE_3D(src2,sampler,coord).x;
+  const float res = w0 * v0 + w1 * v1 + w2 * v2;
+
+  WRITE_IMAGE_3D(dst,coord,(DTYPE_OUT)res);
+}
+
+
+
+__kernel void tenengrad_fusion_with_provided_weights_4_images(
+  DTYPE_IMAGE_OUT_3D dst, const int factor,
+  DTYPE_IMAGE_IN_3D src0, DTYPE_IMAGE_IN_3D src1, DTYPE_IMAGE_IN_3D src2, DTYPE_IMAGE_IN_3D src3,
+  DTYPE_IMAGE_IN_3D weight0, DTYPE_IMAGE_IN_3D weight1, DTYPE_IMAGE_IN_3D weight2, DTYPE_IMAGE_IN_3D weight3
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4)(i,j,k,0);
+
+  const float4 coord_weight = (float4)((i+0.5f)/factor,(j+0.5f)/factor,k+0.5f,0);
+  const sampler_t sampler_weight = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_LINEAR;
+
+  float w0 = read_imagef(weight0,sampler_weight,coord_weight).x;
+  float w1 = read_imagef(weight1,sampler_weight,coord_weight).x;
+  float w2 = read_imagef(weight2,sampler_weight,coord_weight).x;
+  float w3 = read_imagef(weight3,sampler_weight,coord_weight).x;
+
+  const float wsum = w0 + w1 + w2 + w3 + 1e-30f; // add small epsilon to avoid wsum = 0
+  w0 /= wsum;
+  w1 /= wsum;
+  w2 /= wsum;
+  w3 /= wsum;
+
+  const float  v0 = (float)READ_IMAGE_3D(src0,sampler,coord).x;
+  const float  v1 = (float)READ_IMAGE_3D(src1,sampler,coord).x;
+  const float  v2 = (float)READ_IMAGE_3D(src2,sampler,coord).x;
+  const float  v3 = (float)READ_IMAGE_3D(src3,sampler,coord).x;
+  const float res = w0 * v0 + w1 * v1 + w2 * v2 + w3 * v3;
+
+  WRITE_IMAGE_3D(dst,coord,(DTYPE_OUT)res);
+}
+
+
+__kernel void tenengrad_fusion_with_provided_weights_5_images(
+  DTYPE_IMAGE_OUT_3D dst, const int factor,
+  DTYPE_IMAGE_IN_3D src0, DTYPE_IMAGE_IN_3D src1, DTYPE_IMAGE_IN_3D src2, DTYPE_IMAGE_IN_3D src3, DTYPE_IMAGE_IN_3D src4,
+  DTYPE_IMAGE_IN_3D weight0, DTYPE_IMAGE_IN_3D weight1, DTYPE_IMAGE_IN_3D weight2, DTYPE_IMAGE_IN_3D weight3, DTYPE_IMAGE_IN_3D weight4
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4)(i,j,k,0);
+
+  const float4 coord_weight = (float4)((i+0.5f)/factor,(j+0.5f)/factor,k+0.5f,0);
+  const sampler_t sampler_weight = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_LINEAR;
+
+  float w0 = read_imagef(weight0,sampler_weight,coord_weight).x;
+  float w1 = read_imagef(weight1,sampler_weight,coord_weight).x;
+  float w2 = read_imagef(weight2,sampler_weight,coord_weight).x;
+  float w3 = read_imagef(weight3,sampler_weight,coord_weight).x;
+  float w4 = read_imagef(weight4,sampler_weight,coord_weight).x;
+
+  const float wsum = w0 + w1 + w2 + w3 + w4 + 1e-30f; // add small epsilon to avoid wsum = 0
+  w0 /= wsum;
+  w1 /= wsum;
+  w2 /= wsum;
+  w3 /= wsum;
+  w4 /= wsum;
+
+  const float  v0 = (float)READ_IMAGE_3D(src0,sampler,coord).x;
+  const float  v1 = (float)READ_IMAGE_3D(src1,sampler,coord).x;
+  const float  v2 = (float)READ_IMAGE_3D(src2,sampler,coord).x;
+  const float  v3 = (float)READ_IMAGE_3D(src3,sampler,coord).x;
+  const float  v4 = (float)READ_IMAGE_3D(src4,sampler,coord).x;
+  const float res = w0 * v0 + w1 * v1 + w2 * v2 + w3 * v3 + w4 * v4;
+
+  WRITE_IMAGE_3D(dst,coord,(DTYPE_OUT)res);
+}
+
+
+__kernel void tenengrad_fusion_with_provided_weights_6_images(
+  DTYPE_IMAGE_OUT_3D dst, const int factor,
+  DTYPE_IMAGE_IN_3D src0, DTYPE_IMAGE_IN_3D src1, DTYPE_IMAGE_IN_3D src2, DTYPE_IMAGE_IN_3D src3, DTYPE_IMAGE_IN_3D src4, DTYPE_IMAGE_IN_3D src5,
+  DTYPE_IMAGE_IN_3D weight0, DTYPE_IMAGE_IN_3D weight1, DTYPE_IMAGE_IN_3D weight2, DTYPE_IMAGE_IN_3D weight3, DTYPE_IMAGE_IN_3D weight4, DTYPE_IMAGE_IN_3D weight5
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4)(i,j,k,0);
+
+  const float4 coord_weight = (float4)((i+0.5f)/factor,(j+0.5f)/factor,k+0.5f,0);
+  const sampler_t sampler_weight = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_LINEAR;
+
+  float w0 = read_imagef(weight0,sampler_weight,coord_weight).x;
+  float w1 = read_imagef(weight1,sampler_weight,coord_weight).x;
+  float w2 = read_imagef(weight2,sampler_weight,coord_weight).x;
+  float w3 = read_imagef(weight3,sampler_weight,coord_weight).x;
+  float w4 = read_imagef(weight4,sampler_weight,coord_weight).x;
+  float w5 = read_imagef(weight5,sampler_weight,coord_weight).x;
+
+  const float wsum = w0 + w1 + w2 + w3 + w4 + w5 + 1e-30f; // add small epsilon to avoid wsum = 0
+  w0 /= wsum;
+  w1 /= wsum;
+  w2 /= wsum;
+  w3 /= wsum;
+  w4 /= wsum;
+  w5 /= wsum;
+
+  const float  v0 = (float)READ_IMAGE_3D(src0,sampler,coord).x;
+  const float  v1 = (float)READ_IMAGE_3D(src1,sampler,coord).x;
+  const float  v2 = (float)READ_IMAGE_3D(src2,sampler,coord).x;
+  const float  v3 = (float)READ_IMAGE_3D(src3,sampler,coord).x;
+  const float  v4 = (float)READ_IMAGE_3D(src4,sampler,coord).x;
+  const float  v5 = (float)READ_IMAGE_3D(src5,sampler,coord).x;
+  const float res = w0 * v0 + w1 * v1 + w2 * v2 + w3 * v3 + w4 * v4 + w5 * v5;
+
+  WRITE_IMAGE_3D(dst,coord,(DTYPE_OUT)res);
+}
+
+
+__kernel void tenengrad_fusion_with_provided_weights_7_images(
+  DTYPE_IMAGE_OUT_3D dst, const int factor,
+  DTYPE_IMAGE_IN_3D src0, DTYPE_IMAGE_IN_3D src1, DTYPE_IMAGE_IN_3D src2, DTYPE_IMAGE_IN_3D src3, DTYPE_IMAGE_IN_3D src4, DTYPE_IMAGE_IN_3D src5,
+  DTYPE_IMAGE_IN_3D src6,
+  DTYPE_IMAGE_IN_3D weight0, DTYPE_IMAGE_IN_3D weight1, DTYPE_IMAGE_IN_3D weight2, DTYPE_IMAGE_IN_3D weight3, DTYPE_IMAGE_IN_3D weight4, DTYPE_IMAGE_IN_3D weight5,
+  DTYPE_IMAGE_IN_3D weight6
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4)(i,j,k,0);
+
+  const float4 coord_weight = (float4)((i+0.5f)/factor,(j+0.5f)/factor,k+0.5f,0);
+  const sampler_t sampler_weight = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_LINEAR;
+
+  float w0 = read_imagef(weight0,sampler_weight,coord_weight).x;
+  float w1 = read_imagef(weight1,sampler_weight,coord_weight).x;
+  float w2 = read_imagef(weight2,sampler_weight,coord_weight).x;
+  float w3 = read_imagef(weight3,sampler_weight,coord_weight).x;
+  float w4 = read_imagef(weight4,sampler_weight,coord_weight).x;
+  float w5 = read_imagef(weight5,sampler_weight,coord_weight).x;
+  float w6 = read_imagef(weight6,sampler_weight,coord_weight).x;
+
+  const float wsum = w0 + w1 + w2 + w3 + w4 + w5 + w6 + 1e-30f; // add small epsilon to avoid wsum = 0
+  w0 /= wsum;
+  w1 /= wsum;
+  w2 /= wsum;
+  w3 /= wsum;
+  w4 /= wsum;
+  w5 /= wsum;
+  w6 /= wsum;
+
+  const float  v0 = (float)READ_IMAGE_3D(src0,sampler,coord).x;
+  const float  v1 = (float)READ_IMAGE_3D(src1,sampler,coord).x;
+  const float  v2 = (float)READ_IMAGE_3D(src2,sampler,coord).x;
+  const float  v3 = (float)READ_IMAGE_3D(src3,sampler,coord).x;
+  const float  v4 = (float)READ_IMAGE_3D(src4,sampler,coord).x;
+  const float  v5 = (float)READ_IMAGE_3D(src5,sampler,coord).x;
+  const float  v6 = (float)READ_IMAGE_3D(src6,sampler,coord).x;
+  const float res = w0 * v0 + w1 * v1 + w2 * v2 + w3 * v3 + w4 * v4 + w5 * v5 + w6 * v6;
+
+  WRITE_IMAGE_3D(dst,coord,(DTYPE_OUT)res);
+}
+
+
+__kernel void tenengrad_fusion_with_provided_weights_8_images(
+  DTYPE_IMAGE_OUT_3D dst, const int factor,
+  DTYPE_IMAGE_IN_3D src0, DTYPE_IMAGE_IN_3D src1, DTYPE_IMAGE_IN_3D src2, DTYPE_IMAGE_IN_3D src3, DTYPE_IMAGE_IN_3D src4, DTYPE_IMAGE_IN_3D src5,
+  DTYPE_IMAGE_IN_3D src6, DTYPE_IMAGE_IN_3D src7,
+  DTYPE_IMAGE_IN_3D weight0, DTYPE_IMAGE_IN_3D weight1, DTYPE_IMAGE_IN_3D weight2, DTYPE_IMAGE_IN_3D weight3, DTYPE_IMAGE_IN_3D weight4, DTYPE_IMAGE_IN_3D weight5,
+  DTYPE_IMAGE_IN_3D weight6, DTYPE_IMAGE_IN_3D weight7
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4)(i,j,k,0);
+
+  const float4 coord_weight = (float4)((i+0.5f)/factor,(j+0.5f)/factor,k+0.5f,0);
+  const sampler_t sampler_weight = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_LINEAR;
+
+  float w0 = read_imagef(weight0,sampler_weight,coord_weight).x;
+  float w1 = read_imagef(weight1,sampler_weight,coord_weight).x;
+  float w2 = read_imagef(weight2,sampler_weight,coord_weight).x;
+  float w3 = read_imagef(weight3,sampler_weight,coord_weight).x;
+  float w4 = read_imagef(weight4,sampler_weight,coord_weight).x;
+  float w5 = read_imagef(weight5,sampler_weight,coord_weight).x;
+  float w6 = read_imagef(weight6,sampler_weight,coord_weight).x;
+  float w7 = read_imagef(weight7,sampler_weight,coord_weight).x;
+
+  const float wsum = w0 + w1 + w2 + w3 + w4 + w5 + w6 + w7 + 1e-30f; // add small epsilon to avoid wsum = 0
+  w0 /= wsum;
+  w1 /= wsum;
+  w2 /= wsum;
+  w3 /= wsum;
+  w4 /= wsum;
+  w5 /= wsum;
+  w6 /= wsum;
+  w7 /= wsum;
+
+  const float  v0 = (float)READ_IMAGE_3D(src0,sampler,coord).x;
+  const float  v1 = (float)READ_IMAGE_3D(src1,sampler,coord).x;
+  const float  v2 = (float)READ_IMAGE_3D(src2,sampler,coord).x;
+  const float  v3 = (float)READ_IMAGE_3D(src3,sampler,coord).x;
+  const float  v4 = (float)READ_IMAGE_3D(src4,sampler,coord).x;
+  const float  v5 = (float)READ_IMAGE_3D(src5,sampler,coord).x;
+  const float  v6 = (float)READ_IMAGE_3D(src6,sampler,coord).x;
+  const float  v7 = (float)READ_IMAGE_3D(src7,sampler,coord).x;
+  const float res = w0 * v0 + w1 * v1 + w2 * v2 + w3 * v3 + w4 * v4 + w5 * v5 + w6 * v6 + w7 * v7;
+
+  WRITE_IMAGE_3D(dst,coord,(DTYPE_OUT)res);
+}
+
+__kernel void tenengrad_fusion_with_provided_weights_9_images(
+  DTYPE_IMAGE_OUT_3D dst, const int factor,
+  DTYPE_IMAGE_IN_3D src0, DTYPE_IMAGE_IN_3D src1, DTYPE_IMAGE_IN_3D src2, DTYPE_IMAGE_IN_3D src3, DTYPE_IMAGE_IN_3D src4, DTYPE_IMAGE_IN_3D src5,
+  DTYPE_IMAGE_IN_3D src6, DTYPE_IMAGE_IN_3D src7, DTYPE_IMAGE_IN_3D src8,
+  DTYPE_IMAGE_IN_3D weight0, DTYPE_IMAGE_IN_3D weight1, DTYPE_IMAGE_IN_3D weight2, DTYPE_IMAGE_IN_3D weight3, DTYPE_IMAGE_IN_3D weight4, DTYPE_IMAGE_IN_3D weight5,
+  DTYPE_IMAGE_IN_3D weight6, DTYPE_IMAGE_IN_3D weight7, DTYPE_IMAGE_IN_3D weight8
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4)(i,j,k,0);
+
+  const float4 coord_weight = (float4)((i+0.5f)/factor,(j+0.5f)/factor,k+0.5f,0);
+  const sampler_t sampler_weight = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_LINEAR;
+
+  float w0 = read_imagef(weight0,sampler_weight,coord_weight).x;
+  float w1 = read_imagef(weight1,sampler_weight,coord_weight).x;
+  float w2 = read_imagef(weight2,sampler_weight,coord_weight).x;
+  float w3 = read_imagef(weight3,sampler_weight,coord_weight).x;
+  float w4 = read_imagef(weight4,sampler_weight,coord_weight).x;
+  float w5 = read_imagef(weight5,sampler_weight,coord_weight).x;
+  float w6 = read_imagef(weight6,sampler_weight,coord_weight).x;
+  float w7 = read_imagef(weight7,sampler_weight,coord_weight).x;
+  float w8 = read_imagef(weight8,sampler_weight,coord_weight).x;
+
+  const float wsum = w0 + w1 + w2 + w3 + w4 + w5 + w6 + w7 + w8 + 1e-30f; // add small epsilon to avoid wsum = 0
+  w0 /= wsum;
+  w1 /= wsum;
+  w2 /= wsum;
+  w3 /= wsum;
+  w4 /= wsum;
+  w5 /= wsum;
+  w6 /= wsum;
+  w7 /= wsum;
+  w8 /= wsum;
+
+  const float  v0 = (float)READ_IMAGE_3D(src0,sampler,coord).x;
+  const float  v1 = (float)READ_IMAGE_3D(src1,sampler,coord).x;
+  const float  v2 = (float)READ_IMAGE_3D(src2,sampler,coord).x;
+  const float  v3 = (float)READ_IMAGE_3D(src3,sampler,coord).x;
+  const float  v4 = (float)READ_IMAGE_3D(src4,sampler,coord).x;
+  const float  v5 = (float)READ_IMAGE_3D(src5,sampler,coord).x;
+  const float  v6 = (float)READ_IMAGE_3D(src6,sampler,coord).x;
+  const float  v7 = (float)READ_IMAGE_3D(src7,sampler,coord).x;
+  const float  v8 = (float)READ_IMAGE_3D(src8,sampler,coord).x;
+  const float res = w0 * v0 + w1 * v1 + w2 * v2 + w3 * v3 + w4 * v4 + w5 * v5 + w6 * v6 + w7 * v7 + w8 * v8;
+
+  WRITE_IMAGE_3D(dst,coord,(DTYPE_OUT)res);
+}
+
+__kernel void tenengrad_fusion_with_provided_weights_10_images(
+  DTYPE_IMAGE_OUT_3D dst, const int factor,
+  DTYPE_IMAGE_IN_3D src0, DTYPE_IMAGE_IN_3D src1, DTYPE_IMAGE_IN_3D src2, DTYPE_IMAGE_IN_3D src3, DTYPE_IMAGE_IN_3D src4, DTYPE_IMAGE_IN_3D src5,
+  DTYPE_IMAGE_IN_3D src6, DTYPE_IMAGE_IN_3D src7, DTYPE_IMAGE_IN_3D src8, DTYPE_IMAGE_IN_3D src9,
+  DTYPE_IMAGE_IN_3D weight0, DTYPE_IMAGE_IN_3D weight1, DTYPE_IMAGE_IN_3D weight2, DTYPE_IMAGE_IN_3D weight3, DTYPE_IMAGE_IN_3D weight4, DTYPE_IMAGE_IN_3D weight5,
+  DTYPE_IMAGE_IN_3D weight6, DTYPE_IMAGE_IN_3D weight7, DTYPE_IMAGE_IN_3D weight8, DTYPE_IMAGE_IN_3D weight9
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4)(i,j,k,0);
+
+  const float4 coord_weight = (float4)((i+0.5f)/factor,(j+0.5f)/factor,k+0.5f,0);
+  const sampler_t sampler_weight = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_LINEAR;
+
+  float w0 = read_imagef(weight0,sampler_weight,coord_weight).x;
+  float w1 = read_imagef(weight1,sampler_weight,coord_weight).x;
+  float w2 = read_imagef(weight2,sampler_weight,coord_weight).x;
+  float w3 = read_imagef(weight3,sampler_weight,coord_weight).x;
+  float w4 = read_imagef(weight4,sampler_weight,coord_weight).x;
+  float w5 = read_imagef(weight5,sampler_weight,coord_weight).x;
+  float w6 = read_imagef(weight6,sampler_weight,coord_weight).x;
+  float w7 = read_imagef(weight7,sampler_weight,coord_weight).x;
+  float w8 = read_imagef(weight8,sampler_weight,coord_weight).x;
+  float w9 = read_imagef(weight9,sampler_weight,coord_weight).x;
+
+  const float wsum = w0 + w1 + w2 + w3 + w4 + w5 + w6 + w7 + w8 + w9 + 1e-30f; // add small epsilon to avoid wsum = 0
+  w0 /= wsum;
+  w1 /= wsum;
+  w2 /= wsum;
+  w3 /= wsum;
+  w4 /= wsum;
+  w5 /= wsum;
+  w6 /= wsum;
+  w7 /= wsum;
+  w8 /= wsum;
+  w9 /= wsum;
+
+  const float  v0 = (float)READ_IMAGE_3D(src0,sampler,coord).x;
+  const float  v1 = (float)READ_IMAGE_3D(src1,sampler,coord).x;
+  const float  v2 = (float)READ_IMAGE_3D(src2,sampler,coord).x;
+  const float  v3 = (float)READ_IMAGE_3D(src3,sampler,coord).x;
+  const float  v4 = (float)READ_IMAGE_3D(src4,sampler,coord).x;
+  const float  v5 = (float)READ_IMAGE_3D(src5,sampler,coord).x;
+  const float  v6 = (float)READ_IMAGE_3D(src6,sampler,coord).x;
+  const float  v7 = (float)READ_IMAGE_3D(src7,sampler,coord).x;
+  const float  v8 = (float)READ_IMAGE_3D(src8,sampler,coord).x;
+  const float  v9 = (float)READ_IMAGE_3D(src9,sampler,coord).x;
+  const float res = w0 * v0 + w1 * v1 + w2 * v2 + w3 * v3 + w4 * v4 + w5 * v5 + w6 * v6 + w7 * v7 + w8 * v8 + w9 * v9;
+
+  WRITE_IMAGE_3D(dst,coord,(DTYPE_OUT)res);
+}
+
+__kernel void tenengrad_fusion_with_provided_weights_11_images(
+  DTYPE_IMAGE_OUT_3D dst, const int factor,
+  DTYPE_IMAGE_IN_3D src0, DTYPE_IMAGE_IN_3D src1, DTYPE_IMAGE_IN_3D src2, DTYPE_IMAGE_IN_3D src3, DTYPE_IMAGE_IN_3D src4, DTYPE_IMAGE_IN_3D src5,
+  DTYPE_IMAGE_IN_3D src6, DTYPE_IMAGE_IN_3D src7, DTYPE_IMAGE_IN_3D src8, DTYPE_IMAGE_IN_3D src9, DTYPE_IMAGE_IN_3D src10,
+  DTYPE_IMAGE_IN_3D weight0, DTYPE_IMAGE_IN_3D weight1, DTYPE_IMAGE_IN_3D weight2, DTYPE_IMAGE_IN_3D weight3, DTYPE_IMAGE_IN_3D weight4, DTYPE_IMAGE_IN_3D weight5,
+  DTYPE_IMAGE_IN_3D weight6, DTYPE_IMAGE_IN_3D weight7, DTYPE_IMAGE_IN_3D weight8, DTYPE_IMAGE_IN_3D weight9, DTYPE_IMAGE_IN_3D weight10
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4)(i,j,k,0);
+
+  const float4 coord_weight = (float4)((i+0.5f)/factor,(j+0.5f)/factor,k+0.5f,0);
+  const sampler_t sampler_weight = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_LINEAR;
+
+  float w0 = read_imagef(weight0,sampler_weight,coord_weight).x;
+  float w1 = read_imagef(weight1,sampler_weight,coord_weight).x;
+  float w2 = read_imagef(weight2,sampler_weight,coord_weight).x;
+  float w3 = read_imagef(weight3,sampler_weight,coord_weight).x;
+  float w4 = read_imagef(weight4,sampler_weight,coord_weight).x;
+  float w5 = read_imagef(weight5,sampler_weight,coord_weight).x;
+  float w6 = read_imagef(weight6,sampler_weight,coord_weight).x;
+  float w7 = read_imagef(weight7,sampler_weight,coord_weight).x;
+  float w8 = read_imagef(weight8,sampler_weight,coord_weight).x;
+  float w9 = read_imagef(weight9,sampler_weight,coord_weight).x;
+  float w10 = read_imagef(weight9,sampler_weight,coord_weight).x;
+
+  const float wsum = w0 + w1 + w2 + w3 + w4 + w5 + w6 + w7 + w8 + w9 + w10 + 1e-30f; // add small epsilon to avoid wsum = 0
+  w0 /= wsum;
+  w1 /= wsum;
+  w2 /= wsum;
+  w3 /= wsum;
+  w4 /= wsum;
+  w5 /= wsum;
+  w6 /= wsum;
+  w7 /= wsum;
+  w8 /= wsum;
+  w9 /= wsum;
+  w10 /= wsum;
+
+  const float  v0 = (float)READ_IMAGE_3D(src0,sampler,coord).x;
+  const float  v1 = (float)READ_IMAGE_3D(src1,sampler,coord).x;
+  const float  v2 = (float)READ_IMAGE_3D(src2,sampler,coord).x;
+  const float  v3 = (float)READ_IMAGE_3D(src3,sampler,coord).x;
+  const float  v4 = (float)READ_IMAGE_3D(src4,sampler,coord).x;
+  const float  v5 = (float)READ_IMAGE_3D(src5,sampler,coord).x;
+  const float  v6 = (float)READ_IMAGE_3D(src6,sampler,coord).x;
+  const float  v7 = (float)READ_IMAGE_3D(src7,sampler,coord).x;
+  const float  v8 = (float)READ_IMAGE_3D(src8,sampler,coord).x;
+  const float  v9 = (float)READ_IMAGE_3D(src9,sampler,coord).x;
+  const float  v10 = (float)READ_IMAGE_3D(src10,sampler,coord).x;
+  const float res = w0 * v0 + w1 * v1 + w2 * v2 + w3 * v3 + w4 * v4 + w5 * v5 + w6 * v6 + w7 * v7 + w8 * v8 + w9 * v9 + w10 * v10;
+
+  WRITE_IMAGE_3D(dst,coord,(DTYPE_OUT)res);
+}
+
+__kernel void tenengrad_fusion_with_provided_weights_12_images(
+  DTYPE_IMAGE_OUT_3D dst, const int factor,
+  DTYPE_IMAGE_IN_3D src0, DTYPE_IMAGE_IN_3D src1, DTYPE_IMAGE_IN_3D src2, DTYPE_IMAGE_IN_3D src3, DTYPE_IMAGE_IN_3D src4, DTYPE_IMAGE_IN_3D src5,
+  DTYPE_IMAGE_IN_3D src6, DTYPE_IMAGE_IN_3D src7, DTYPE_IMAGE_IN_3D src8, DTYPE_IMAGE_IN_3D src9, DTYPE_IMAGE_IN_3D src10, DTYPE_IMAGE_IN_3D src11,
+  DTYPE_IMAGE_IN_3D weight0, DTYPE_IMAGE_IN_3D weight1, DTYPE_IMAGE_IN_3D weight2, DTYPE_IMAGE_IN_3D weight3, DTYPE_IMAGE_IN_3D weight4, DTYPE_IMAGE_IN_3D weight5,
+  DTYPE_IMAGE_IN_3D weight6, DTYPE_IMAGE_IN_3D weight7, DTYPE_IMAGE_IN_3D weight8, DTYPE_IMAGE_IN_3D weight9, DTYPE_IMAGE_IN_3D weight10, DTYPE_IMAGE_IN_3D weight11
+)
+{
+  const int i = get_global_id(0), j = get_global_id(1), k = get_global_id(2);
+  const int4 coord = (int4)(i,j,k,0);
+
+  const float4 coord_weight = (float4)((i+0.5f)/factor,(j+0.5f)/factor,k+0.5f,0);
+  const sampler_t sampler_weight = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_LINEAR;
+
+  float w0 = read_imagef(weight0,sampler_weight,coord_weight).x;
+  float w1 = read_imagef(weight1,sampler_weight,coord_weight).x;
+  float w2 = read_imagef(weight2,sampler_weight,coord_weight).x;
+  float w3 = read_imagef(weight3,sampler_weight,coord_weight).x;
+  float w4 = read_imagef(weight4,sampler_weight,coord_weight).x;
+  float w5 = read_imagef(weight5,sampler_weight,coord_weight).x;
+  float w6 = read_imagef(weight6,sampler_weight,coord_weight).x;
+  float w7 = read_imagef(weight7,sampler_weight,coord_weight).x;
+  float w8 = read_imagef(weight8,sampler_weight,coord_weight).x;
+  float w9 = read_imagef(weight9,sampler_weight,coord_weight).x;
+  float w10 = read_imagef(weight9,sampler_weight,coord_weight).x;
+  float w11 = read_imagef(weight9,sampler_weight,coord_weight).x;
+
+  const float wsum = w0 + w1 + w2 + w3 + w4 + w5 + w6 + w7 + w8 + w9 + w10 + w11 + 1e-30f; // add small epsilon to avoid wsum = 0
+  w0 /= wsum;
+  w1 /= wsum;
+  w2 /= wsum;
+  w3 /= wsum;
+  w4 /= wsum;
+  w5 /= wsum;
+  w6 /= wsum;
+  w7 /= wsum;
+  w8 /= wsum;
+  w9 /= wsum;
+  w10 /= wsum;
+  w11 /= wsum;
+
+  const float  v0 = (float)READ_IMAGE_3D(src0,sampler,coord).x;
+  const float  v1 = (float)READ_IMAGE_3D(src1,sampler,coord).x;
+  const float  v2 = (float)READ_IMAGE_3D(src2,sampler,coord).x;
+  const float  v3 = (float)READ_IMAGE_3D(src3,sampler,coord).x;
+  const float  v4 = (float)READ_IMAGE_3D(src4,sampler,coord).x;
+  const float  v5 = (float)READ_IMAGE_3D(src5,sampler,coord).x;
+  const float  v6 = (float)READ_IMAGE_3D(src6,sampler,coord).x;
+  const float  v7 = (float)READ_IMAGE_3D(src7,sampler,coord).x;
+  const float  v8 = (float)READ_IMAGE_3D(src8,sampler,coord).x;
+  const float  v9 = (float)READ_IMAGE_3D(src9,sampler,coord).x;
+  const float  v10 = (float)READ_IMAGE_3D(src10,sampler,coord).x;
+  const float  v11 = (float)READ_IMAGE_3D(src11,sampler,coord).x;
+  const float res = w0 * v0 + w1 * v1 + w2 * v2 + w3 * v3 + w4 * v4 + w5 * v5 + w6 * v6 + w7 * v7 + w8 * v8 + w9 * v9 + w10 * v10 + w11 * v11;
+
+  WRITE_IMAGE_3D(dst,coord,(DTYPE_OUT)res);
+}

--- a/src/main/java/clearcl/ocllib/kernels/test.cl
+++ b/src/main/java/clearcl/ocllib/kernels/test.cl
@@ -1,0 +1,29 @@
+
+__kernel void set_pixels_to_width_src1_3d(
+DTYPE_IMAGE_IN_3D src1,
+DTYPE_IMAGE_IN_3D src2,
+DTYPE_IMAGE_OUT_3D  dst)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  float value = GET_IMAGE_IN_WIDTH(src1);
+
+  WRITE_IMAGE_3D (dst, (int4)(x,y,z,0), (DTYPE_OUT)value);
+}
+
+__kernel void set_pixels_to_width_src2_3d(
+DTYPE_IMAGE_IN_3D src1,
+DTYPE_IMAGE_IN_3D src2,
+DTYPE_IMAGE_OUT_3D  dst)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  float value = GET_IMAGE_IN_WIDTH(src2);
+
+  WRITE_IMAGE_3D (dst, (int4)(x,y,z,0), (DTYPE_OUT)value);
+}
+

--- a/src/main/java/clearcl/ocllib/kernels/thresholding.cl
+++ b/src/main/java/clearcl/ocllib/kernels/thresholding.cl
@@ -1,0 +1,83 @@
+__constant sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+__kernel void apply_threshold_3d(DTYPE_IMAGE_IN_3D  src,
+                                 const    float      threshold,
+                          DTYPE_IMAGE_OUT_3D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  DTYPE_IN inputValue = READ_IMAGE_3D(src, sampler, pos).x;
+  DTYPE_OUT value = 1.0;
+  if (inputValue < threshold) {
+    value = 0.0;
+  }
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+__kernel void apply_threshold_2d(DTYPE_IMAGE_IN_2D  src,
+                                 const    float      threshold,
+                          DTYPE_IMAGE_OUT_2D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int2 pos = (int2){x,y};
+
+  DTYPE_IN inputValue = READ_IMAGE_2D(src, sampler, pos).x;
+  DTYPE_OUT value = 1.0;
+  if (inputValue < threshold) {
+    value = 0.0;
+  }
+
+  WRITE_IMAGE_2D (dst, pos, value);
+}
+
+
+__kernel void apply_local_threshold_3d(DTYPE_IMAGE_IN_3D  src,
+                                 DTYPE_IMAGE_IN_3D local_threshold,
+                          DTYPE_IMAGE_OUT_3D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int z = get_global_id(2);
+
+  const int4 pos = (int4){x,y,z,0};
+
+  DTYPE_IN inputValue = READ_IMAGE_3D(src, sampler, pos).x;
+  DTYPE_IN threshold = READ_IMAGE_3D(local_threshold, sampler, pos).x;
+
+  DTYPE_OUT value = 1.0;
+  if (inputValue < threshold) {
+    value = 0.0;
+  }
+
+  WRITE_IMAGE_3D (dst, pos, value);
+}
+
+__kernel void apply_local_threshold_2d(DTYPE_IMAGE_IN_2D  src,
+                                 DTYPE_IMAGE_IN_2D local_threshold,
+                          DTYPE_IMAGE_OUT_2D  dst
+                     )
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  const int2 pos = (int2){x,y};
+
+  DTYPE_IN inputValue = READ_IMAGE_2D(src, sampler, pos).x;
+  DTYPE_IN threshold = READ_IMAGE_2D(local_threshold, sampler, pos).x;
+  DTYPE_OUT value = 1.0;
+  if (inputValue < threshold) {
+    value = 0.0;
+  }
+
+  WRITE_IMAGE_2D (dst, pos, value);
+}

--- a/src/main/java/clearcl/ops/kernels/CLKernelExecutor.java
+++ b/src/main/java/clearcl/ops/kernels/CLKernelExecutor.java
@@ -1,0 +1,711 @@
+package clearcl.ops.kernels;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import clearcl.ClearCLBuffer;
+import clearcl.ClearCLContext;
+import clearcl.ClearCLImage;
+import clearcl.ClearCLKernel;
+import clearcl.ClearCLProgram;
+import clearcl.enums.HostAccessType;
+import clearcl.enums.ImageChannelDataType;
+import clearcl.enums.ImageChannelOrder;
+import clearcl.enums.KernelAccessType;
+import clearcl.enums.MemAllocMode;
+import clearcl.exceptions.OpenCLException;
+import clearcl.util.ElapsedTime;
+import coremem.enums.NativeTypeEnum;
+
+/**
+ * This executor can call OpenCL files. It uses some functionality adapted from
+ * FastFuse, to make .cl file handling easier. For example, it ensures that the
+ * right image_read/image_write methods are called depending on the image type.
+ * <p>
+ * Author: Robert Haase (http://haesleinhuepf.net) at MPI CBG
+ * (http://mpi-cbg.de) February 2018
+ */
+public class CLKernelExecutor
+{
+  public static int MAX_ARRAY_SIZE = 1000;
+  private final ClearCLContext context;
+  private Class anchorClass;
+  String programFilename;
+  String kernelName;
+  Map<String, Object> parameterMap;
+  long[] globalSizes;
+
+  private final HashMap<String, ClearCLProgram> programCacheMap =
+                                                                new HashMap();
+  ClearCLProgram currentProgram = null;
+
+  private static final boolean DEBUG = false;
+
+  private final HashMap<String, ArrayList<String>> variableListMap =
+                                                                   new HashMap<>();
+  private final HashMap<String, String> sourceCodeCache =
+                                                        new HashMap<>();
+
+  public CLKernelExecutor(ClearCLContext context,
+                          Class anchorClass,
+                          String programFilename,
+                          String kernelName,
+                          long[] globalSizes) throws IOException
+  {
+    super();
+    this.context = context;
+    this.anchorClass = anchorClass;
+    this.programFilename = programFilename;
+    this.kernelName = kernelName;
+    this.globalSizes = globalSizes;
+  }
+
+  public static void getOpenCLDefines(Map<String, Object> defines,
+                                      ImageChannelDataType imageChannelDataType,
+                                      boolean isInputImage)
+  {
+    if (isInputImage)
+    {
+      defines.put("DTYPE_IMAGE_IN_3D", "__read_only image3d_t");
+      defines.put("DTYPE_IMAGE_IN_2D", "__read_only image2d_t");
+      if (imageChannelDataType.isInteger())
+      {
+        if (imageChannelDataType == ImageChannelDataType.UnsignedInt8
+            || imageChannelDataType == ImageChannelDataType.SignedInt8)
+        {
+          defines.put("DTYPE_IN", "char");
+        }
+        else
+        {
+          defines.put("DTYPE_IN", "ushort");
+        }
+      }
+      else
+      {
+        defines.put("DTYPE_IN", "float");
+      }
+      defines.put("READ_IMAGE_2D",
+                  imageChannelDataType.isInteger() ? "read_imageui"
+                                                   : "read_imagef");
+      defines.put("READ_IMAGE_3D",
+                  imageChannelDataType.isInteger() ? "read_imageui"
+                                                   : "read_imagef");
+    }
+    else
+    {
+      defines.put("DTYPE_IMAGE_OUT_3D", "__write_only image3d_t");
+      defines.put("DTYPE_IMAGE_OUT_2D", "__write_only image2d_t");
+      if (imageChannelDataType.isInteger())
+      {
+        if (imageChannelDataType == ImageChannelDataType.UnsignedInt8
+            || imageChannelDataType == ImageChannelDataType.SignedInt8)
+        {
+          defines.put("DTYPE_OUT", "char");
+        }
+        else
+        {
+          defines.put("DTYPE_OUT", "ushort");
+        }
+      }
+      else
+      {
+        defines.put("DTYPE_OUT", "float");
+      }
+      defines.put("WRITE_IMAGE_2D",
+                  imageChannelDataType.isInteger() ? "write_imageui"
+                                                   : "write_imagef");
+      defines.put("WRITE_IMAGE_3D",
+                  imageChannelDataType.isInteger() ? "write_imageui"
+                                                   : "write_imagef");
+    }
+  }
+
+  public static void getOpenCLDefines(Map<String, Object> defines,
+                                      NativeTypeEnum nativeTypeEnum,
+                                      boolean isInputImage)
+  {
+    String typeName = nativeTypeToOpenCLTypeName(nativeTypeEnum);
+    String typeId = nativeTypeToOpenCLTypeShortName(nativeTypeEnum);
+
+    if (isInputImage)
+    {
+      defines.put("DTYPE_IN", typeName);
+      defines.put("DTYPE_IMAGE_IN_3D", "__global " + typeName + "*");
+      defines.put("DTYPE_IMAGE_IN_2D", "__global " + typeName + "*");
+      defines.put("READ_IMAGE_2D(a,b,c)", "read_buffer2d" + typeId
+                                          + "(GET_IMAGE_WIDTH(a),GET_IMAGE_HEIGHT(a),GET_IMAGE_DEPTH(a),a,b,c)");
+      defines.put("READ_IMAGE_3D(a,b,c)", "read_buffer3d" + typeId
+                                          + "(GET_IMAGE_WIDTH(a),GET_IMAGE_HEIGHT(a),GET_IMAGE_DEPTH(a),a,b,c)");
+    }
+    else
+    {
+      defines.put("DTYPE_OUT", typeName);
+      defines.put("DTYPE_IMAGE_OUT_3D", "__global " + typeName + "*");
+      defines.put("DTYPE_IMAGE_OUT_2D", "__global " + typeName + "*");
+      defines.put("WRITE_IMAGE_2D(a,b,c)", "write_buffer2d" + typeId
+                                           + "(GET_IMAGE_WIDTH(a),GET_IMAGE_HEIGHT(a),GET_IMAGE_DEPTH(a),a,b,c)");
+      defines.put("WRITE_IMAGE_3D(a,b,c)", "write_buffer3d" + typeId
+                                           + "(GET_IMAGE_WIDTH(a),GET_IMAGE_HEIGHT(a),GET_IMAGE_DEPTH(a),a,b,c)");
+    }
+  }
+
+  private static String nativeTypeToOpenCLTypeName(NativeTypeEnum pDType)
+  {
+    if (null == pDType)
+    {
+      return "";
+    }
+    else
+      switch (pDType)
+      {
+      case Byte:
+        return "char";
+      case UnsignedByte:
+        return "uchar";
+      case Short:
+        return "short";
+      case UnsignedShort:
+        return "ushort";
+      case Float:
+        return "float";
+      default:
+        return "";
+      }
+  }
+
+  private static String nativeTypeToOpenCLTypeShortName(NativeTypeEnum pDType)
+  {
+    if (null == pDType)
+    {
+      return "";
+    }
+    else
+      switch (pDType)
+      {
+      case Byte:
+        return "c";
+      case UnsignedByte:
+        return "uc";
+      case Short:
+        return "i";
+      case UnsignedShort:
+        return "ui";
+      case Float:
+        return "f";
+      default:
+        return "";
+      }
+  }
+
+  public ClearCLBuffer createCLBuffer(ClearCLBuffer inputCL)
+  {
+    return createCLBuffer(inputCL.getDimensions(),
+                          inputCL.getNativeType());
+  }
+
+  public ClearCLBuffer createCLBuffer(long[] dimensions,
+                                      NativeTypeEnum pNativeType)
+  {
+    return context.createBuffer(MemAllocMode.Best,
+                                HostAccessType.ReadWrite,
+                                KernelAccessType.ReadWrite,
+                                1L,
+                                pNativeType,
+                                dimensions);
+  }
+
+  public ClearCLImage createCLImage(ClearCLImage pInputImage)
+  {
+    return context.createImage(pInputImage);
+  }
+
+  public ClearCLImage createCLImage(long[] dimensions,
+                                    ImageChannelDataType pImageChannelType)
+  {
+    return context.createImage(HostAccessType.ReadWrite,
+                               KernelAccessType.ReadWrite,
+                               ImageChannelOrder.R,
+                               pImageChannelType,
+                               dimensions);
+  }
+
+  public boolean execute(String pProgramFilename,
+                         String pKernelname,
+                         Map<String, Object> pParameterMap)
+  {
+    return execute(Object.class,
+                   pProgramFilename,
+                   pKernelname,
+                   pParameterMap);
+  }
+
+  public boolean execute(Class pAnchorClass,
+                         String pProgramFilename,
+                         String pKernelname,
+                         Map<String, Object> pParameterMap)
+  {
+    return execute(pAnchorClass,
+                   pProgramFilename,
+                   pKernelname,
+                   null,
+                   pParameterMap);
+  }
+
+  public boolean execute(Class pAnchorClass,
+                         String pProgramFilename,
+                         String pKernelname,
+                         long[] pGlobalsizes,
+                         Map<String, Object> pParameterMap)
+  {
+    final boolean[] result = new boolean[1];
+
+    if (DEBUG)
+    {
+      for (String key : pParameterMap.keySet())
+      {
+        System.out.println(key + " = " + pParameterMap.get(key));
+      }
+    }
+
+    ElapsedTime.measure("kernel + build " + pKernelname, () -> {
+      this.setProgramFilename(pProgramFilename);
+      this.setKernelName(pKernelname);
+      this.setAnchorClass(pAnchorClass);
+      this.setParameterMap(pParameterMap);
+      this.setGlobalSizes(pGlobalsizes);
+
+      this.setParameterMap(pParameterMap);
+      result[0] = this.enqueue(true);
+    });
+    return result[0];
+  }
+
+  /**
+   * Map of all parameters. It is recommended that input and output images are
+   * given with the names "src" and "dst", respectively.
+   *
+   * @param parameterMap
+   */
+  public void setParameterMap(Map<String, Object> parameterMap)
+  {
+    this.parameterMap = parameterMap;
+  }
+
+  public boolean enqueue(boolean waitToFinish)
+  {
+    if (DEBUG)
+    {
+      System.out.println("Loading " + kernelName);
+    }
+
+    ClearCLImage srcImage = null;
+    ClearCLImage dstImage = null;
+    ClearCLBuffer srcBuffer = null;
+    ClearCLBuffer dstBuffer = null;
+
+    if (parameterMap != null)
+    {
+      for (String key : parameterMap.keySet())
+      {
+        if (parameterMap.get(key) instanceof ClearCLImage)
+        {
+          if (key.contains("src") || key.contains("input"))
+          {
+            srcImage = (ClearCLImage) parameterMap.get(key);
+          }
+          else if (key.contains("dst") || key.contains("output"))
+          {
+            dstImage = (ClearCLImage) parameterMap.get(key);
+          }
+        }
+        else if (parameterMap.get(key) instanceof ClearCLBuffer)
+        {
+          if (key.contains("src") || key.contains("input"))
+          {
+            srcBuffer = (ClearCLBuffer) parameterMap.get(key);
+          }
+          else if (key.contains("dst") || key.contains("output"))
+          {
+            dstBuffer = (ClearCLBuffer) parameterMap.get(key);
+          }
+        }
+      }
+    }
+
+    if (dstImage == null && dstBuffer == null)
+    {
+      if (srcImage != null)
+      {
+        dstImage = srcImage;
+      }
+      else if (srcBuffer != null)
+      {
+        dstBuffer = srcBuffer;
+      }
+    }
+    else if (srcImage == null && srcBuffer == null)
+    {
+      if (dstImage != null)
+      {
+        srcImage = dstImage;
+      }
+      else if (dstBuffer != null)
+      {
+        srcBuffer = dstBuffer;
+      }
+    }
+
+    Map<String, Object> openCLDefines = new HashMap();
+    openCLDefines.put("MAX_ARRAY_SIZE", MAX_ARRAY_SIZE); // needed for median.
+                                                         // Median is limited to
+                                                         // a given array length
+                                                         // to be sorted
+    if (srcImage != null)
+    {
+      getOpenCLDefines(openCLDefines,
+                       srcImage.getChannelDataType(),
+                       true);
+    }
+    if (dstImage != null)
+    {
+      getOpenCLDefines(openCLDefines,
+                       dstImage.getChannelDataType(),
+                       false);
+    }
+    if (srcBuffer != null)
+    {
+      getOpenCLDefines(openCLDefines,
+                       srcBuffer.getNativeType(),
+                       true);
+    }
+    if (dstBuffer != null)
+    {
+      getOpenCLDefines(openCLDefines,
+                       dstBuffer.getNativeType(),
+                       false);
+    }
+
+    // deal with image width/height/depth for all images and buffers
+    ArrayList<String> definedParameterKeys = new ArrayList<>();
+    for (String key : parameterMap.keySet())
+    {
+      if (parameterMap.get(key) instanceof ClearCLImage)
+      {
+        ClearCLImage image = (ClearCLImage) parameterMap.get(key);
+        openCLDefines.put("IMAGE_SIZE_" + key
+                          + "_WIDTH",
+                          image.getWidth());
+        openCLDefines.put("IMAGE_SIZE_" + key
+                          + "_HEIGHT",
+                          image.getHeight());
+        openCLDefines.put("IMAGE_SIZE_" + key
+                          + "_DEPTH",
+                          image.getDepth());
+      }
+      else if (parameterMap.get(key) instanceof ClearCLBuffer)
+      {
+        ClearCLBuffer image = (ClearCLBuffer) parameterMap.get(key);
+        openCLDefines.put("IMAGE_SIZE_" + key
+                          + "_WIDTH",
+                          image.getWidth());
+        openCLDefines.put("IMAGE_SIZE_" + key
+                          + "_HEIGHT",
+                          image.getHeight());
+        openCLDefines.put("IMAGE_SIZE_" + key
+                          + "_DEPTH",
+                          image.getDepth());
+      }
+      definedParameterKeys.add(key);
+    }
+
+    openCLDefines.put("GET_IMAGE_IN_WIDTH(image_key)",
+                      "IMAGE_SIZE_ ## image_key ## _WIDTH");
+    openCLDefines.put("GET_IMAGE_IN_HEIGHT(image_key)",
+                      "IMAGE_SIZE_ ## image_key ## _HEIGHT");
+    openCLDefines.put("GET_IMAGE_IN_DEPTH(image_key)",
+                      "IMAGE_SIZE_ ## image_key ## _DEPTH");
+    openCLDefines.put("GET_IMAGE_OUT_WIDTH(image_key)",
+                      "IMAGE_SIZE_ ## image_key ## _WIDTH");
+    openCLDefines.put("GET_IMAGE_OUT_HEIGHT(image_key)",
+                      "IMAGE_SIZE_ ## image_key ## _HEIGHT");
+    openCLDefines.put("GET_IMAGE_OUT_DEPTH(image_key)",
+                      "IMAGE_SIZE_ ## image_key ## _DEPTH");
+    openCLDefines.put("GET_IMAGE_WIDTH(image_key)",
+                      "IMAGE_SIZE_ ## image_key ## _WIDTH");
+    openCLDefines.put("GET_IMAGE_HEIGHT(image_key)",
+                      "IMAGE_SIZE_ ## image_key ## _HEIGHT");
+    openCLDefines.put("GET_IMAGE_DEPTH(image_key)",
+                      "IMAGE_SIZE_ ## image_key ## _DEPTH");
+
+    // add undefined parameters to define list
+    ArrayList<String> variableNames = getImageVariablesFromSource();
+    for (String variableName : variableNames)
+    {
+
+      boolean existsAlready = false;
+      for (String key : definedParameterKeys)
+      {
+        if (key.compareTo(variableName) == 0)
+        {
+          existsAlready = true;
+          break;
+        }
+      }
+      if (!existsAlready)
+      {
+        openCLDefines.put("IMAGE_SIZE_" + variableName + "_WIDTH", 0);
+        openCLDefines.put("IMAGE_SIZE_" + variableName
+                          + "_HEIGHT",
+                          0);
+        openCLDefines.put("IMAGE_SIZE_" + variableName + "_DEPTH", 0);
+      }
+    }
+
+    if (DEBUG)
+    {
+      for (String key : openCLDefines.keySet())
+      {
+        System.out.println(key + " = " + openCLDefines.get(key));
+      }
+    }
+
+    ClearCLKernel clearCLKernel;
+
+    try
+    {
+      clearCLKernel = getKernel(context, kernelName, openCLDefines);
+    }
+    catch (IOException e1)
+    {
+      // e1.printStackTrace();
+      System.out.println("IOException accessing clearCLKernal: "
+                         + kernelName);
+      return false;
+    }
+
+    if (clearCLKernel != null)
+    {
+      if (globalSizes != null)
+      {
+        clearCLKernel.setGlobalSizes(globalSizes);
+      }
+      else if (dstImage != null)
+      {
+        clearCLKernel.setGlobalSizes(dstImage.getDimensions());
+      }
+      else if (dstBuffer != null)
+      {
+        clearCLKernel.setGlobalSizes(dstBuffer.getDimensions());
+      }
+      if (parameterMap != null)
+      {
+        for (String key : parameterMap.keySet())
+        {
+          clearCLKernel.setArgument(key, parameterMap.get(key));
+        }
+      }
+      if (DEBUG)
+      {
+        System.out.println("Executing " + kernelName);
+      }
+
+      final ClearCLKernel kernel = clearCLKernel;
+      double duration = ElapsedTime.measure("Pure kernel execution",
+                                            () -> {
+                                              try
+                                              {
+                                                kernel.run(waitToFinish);
+                                              }
+                                              catch (Exception e)
+                                              {
+                                                // e.printStackTrace();
+                                                System.out.println(kernel.getSourceCode());
+                                              }
+                                            });
+      if (DEBUG)
+      {
+        System.out.println("Returned from " + kernelName
+                           + " after "
+                           + duration
+                           + " msec");
+      }
+      clearCLKernel.close();
+    }
+
+    return true;
+  }
+
+  private ArrayList<String> getImageVariablesFromSource()
+  {
+    String key = anchorClass.getName() + "_" + programFilename;
+
+    if (variableListMap.containsKey(key))
+    {
+      return variableListMap.get(key);
+    }
+    ArrayList<String> variableList = new ArrayList<>();
+
+    String sourceCode = getProgramSource();
+    String[] kernels = sourceCode.split("__kernel");
+
+    kernels[0] = "";
+    for (String kernel : kernels)
+    {
+      if (kernel.length() > 0)
+      {
+        String temp1 = kernel.split("\\(")[1];
+        if (temp1.length() > 0)
+        {
+          String parameterText = temp1.split("\\)")[0];
+          parameterText = parameterText.replace("\n", " ");
+          parameterText = parameterText.replace("\t", " ");
+          parameterText = parameterText.replace("\r", " ");
+
+          String[] parameters = parameterText.split(",");
+          for (String parameter : parameters)
+          {
+            if (parameter.contains("IMAGE"))
+            {
+              String[] temp2 = parameter.trim().split(" ");
+              String variableName = temp2[temp2.length - 1];
+
+              variableList.add(variableName);
+
+            }
+          }
+        }
+      }
+    }
+
+    variableListMap.put(key, variableList);
+    return variableList;
+  }
+
+  protected String getProgramSource()
+  {
+    String key = anchorClass.getName() + "_" + programFilename;
+
+    if (sourceCodeCache.containsKey(key))
+    {
+      return sourceCodeCache.get(key);
+    }
+    try
+    {
+      ClearCLProgram program = context.createProgram(this.anchorClass,
+                                                     new String[]
+                                                     { this.programFilename });
+      String source = program.getSourceCode();
+      sourceCodeCache.put(key, source);
+      return source;
+    }
+    catch (IOException e)
+    {
+      // e.printStackTrace();
+      System.out.println("IOException creating program: "
+                         + this.programFilename);
+    }
+    return "";
+  }
+
+  public void setAnchorClass(Class anchorClass)
+  {
+    this.anchorClass = anchorClass;
+  }
+
+  public void setProgramFilename(String programFilename)
+  {
+    this.programFilename = programFilename;
+  }
+
+  public void setKernelName(String kernelName)
+  {
+    this.kernelName = kernelName;
+  }
+
+  public void setGlobalSizes(long[] globalSizes)
+  {
+    this.globalSizes = globalSizes;
+  }
+
+  protected ClearCLKernel getKernel(ClearCLContext context,
+                                    String kernelName) throws IOException
+  {
+    return this.getKernel(context, kernelName, (Map) null);
+  }
+
+  protected ClearCLKernel getKernel(ClearCLContext context,
+                                    String kernelName,
+                                    Map<String, Object> defines) throws IOException,
+                                                                 NullPointerException
+  {
+    String programCacheKey = anchorClass.getCanonicalName() + " "
+                             + programFilename;
+    for (String key : defines.keySet())
+    {
+      programCacheKey = programCacheKey + " "
+                        + (key + " = " + defines.get(key));
+    }
+    if (DEBUG)
+    {
+      System.out.println("Program cache hash:" + programCacheKey);
+    }
+    ClearCLProgram clProgram =
+                             this.programCacheMap.get(programCacheKey);
+    currentProgram = clProgram;
+    if (clProgram == null)
+    {
+      clProgram = context.createProgram(this.anchorClass, new String[]
+      { this.programFilename });
+      Iterator iterator = defines.entrySet().iterator();
+
+      while (iterator.hasNext())
+      {
+        Map.Entry<String, Object> entry = (Map.Entry) iterator.next();
+        if (entry.getValue() instanceof String)
+        {
+          clProgram.addDefine((String) entry.getKey(),
+                              (String) entry.getValue());
+        }
+        else if (entry.getValue() instanceof Number)
+        {
+          clProgram.addDefine((String) entry.getKey(),
+                              (Number) entry.getValue());
+        }
+        else if (entry.getValue() == null)
+        {
+          clProgram.addDefine((String) entry.getKey());
+        }
+      }
+
+      clProgram.addBuildOptionAllMathOpt();
+      clProgram.buildAndLog();
+
+      programCacheMap.put(programCacheKey, clProgram);
+    }
+
+    try
+    {
+      return clProgram.createKernel(kernelName);
+    }
+    catch (OpenCLException e)
+    {
+      System.out.println("Error when trying to create kernel "
+                         + kernelName);
+      // e.printStackTrace();
+      return null;
+    }
+  }
+
+  public void close()
+  {
+    for (String key : programCacheMap.keySet())
+    {
+      ClearCLProgram program = programCacheMap.get(key);
+      program.close();
+    }
+    programCacheMap.clear();
+  }
+}

--- a/src/main/java/clearcl/ops/kernels/KernelUtils.java
+++ b/src/main/java/clearcl/ops/kernels/KernelUtils.java
@@ -1,0 +1,33 @@
+package clearcl.ops.kernels;
+
+/**
+ * CLIJUtilities
+ * <p>
+ * Author: @haesleinhuepf December 2018
+ */
+public class KernelUtils
+{
+
+  public static int radiusToKernelSize(int radius)
+  {
+    int kernelSize = radius * 2 + 1;
+    return kernelSize;
+  }
+
+  public static int sigmaToKernelSize(float sigma)
+  {
+    int n = (int) (sigma * 8.0);
+    if (n % 2 == 0)
+    {
+      n++;
+    }
+    return n;
+  }
+
+  public static String classToName(Class aClass)
+  {
+    String name = aClass.getSimpleName();
+    return "CLIJ_" + name.substring(0, 1).toLowerCase()
+           + name.substring(1, name.length());
+  }
+}

--- a/src/main/java/clearcl/ops/kernels/Kernels.java
+++ b/src/main/java/clearcl/ops/kernels/Kernels.java
@@ -1,0 +1,4456 @@
+package clearcl.ops.kernels;
+
+import static clearcl.ops.kernels.KernelUtils.radiusToKernelSize;
+import static clearcl.ops.kernels.KernelUtils.sigmaToKernelSize;
+
+import java.nio.FloatBuffer;
+import java.util.HashMap;
+
+import clearcl.ClearCLBuffer;
+import clearcl.ClearCLImage;
+import coremem.enums.NativeTypeEnum;
+
+/**
+ * This class contains convenience access functions for OpenCL based image
+ * processing.
+ * <p>
+ * Author: Robert Haase (http://haesleinhuepf.net) at MPI CBG
+ * (http://mpi-cbg.de) March 2018
+ */
+public class Kernels
+{
+
+  public static boolean absolute(CLKernelExecutor clke,
+                                 ClearCLImage src,
+                                 ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (addImageAndScalar)");
+    }
+
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "absolute_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean absolute(CLKernelExecutor clke,
+                                 ClearCLBuffer src,
+                                 ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (addImageAndScalar)");
+    }
+
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "absolute_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean addImages(CLKernelExecutor clke,
+                                  ClearCLImage src,
+                                  ClearCLImage src1,
+                                  ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("src1", src1);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(),
+                         src1.getDimension(),
+                         dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (addImages)");
+    }
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "addPixelwise_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean addImages(CLKernelExecutor clke,
+                                  ClearCLBuffer src,
+                                  ClearCLBuffer src1,
+                                  ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("src1", src1);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(),
+                         src1.getDimension(),
+                         dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (addImages)");
+    }
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "addPixelwise_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean addImageAndScalar(CLKernelExecutor clke,
+                                          ClearCLImage src,
+                                          ClearCLImage dst,
+                                          Float scalar)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("scalar", scalar);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (addImageAndScalar)");
+    }
+
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "addScalar_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean addImageAndScalar(CLKernelExecutor clke,
+                                          ClearCLBuffer src,
+                                          ClearCLBuffer dst,
+                                          Float scalar)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("scalar", scalar);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (addImageAndScalar)");
+    }
+
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "addScalar_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean addImagesWeighted(CLKernelExecutor clke,
+                                          ClearCLImage src,
+                                          ClearCLImage src1,
+                                          ClearCLImage dst,
+                                          Float factor,
+                                          Float factor1)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("src1", src1);
+    parameters.put("factor", factor);
+    parameters.put("factor1", factor1);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(),
+                         src1.getDimension(),
+                         dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (addImageAndScalar)");
+    }
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "addWeightedPixelwise_" + src.getDimension()
+                                   + "d",
+                        parameters);
+  }
+
+  public static boolean addImagesWeighted(CLKernelExecutor clke,
+                                          ClearCLBuffer src,
+                                          ClearCLBuffer src1,
+                                          ClearCLBuffer dst,
+                                          Float factor,
+                                          Float factor1)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("src1", src1);
+    parameters.put("factor", factor);
+    parameters.put("factor1", factor1);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(),
+                         src1.getDimension(),
+                         dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (addImageAndScalar)");
+    }
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "addWeightedPixelwise_" + src.getDimension()
+                                   + "d",
+                        parameters);
+  }
+
+  public static boolean affineTransform(CLKernelExecutor clke,
+                                        ClearCLBuffer src,
+                                        ClearCLBuffer dst,
+                                        float[] matrix)
+  {
+
+    ClearCLBuffer matrixCl = clke.createCLBuffer(new long[]
+    { matrix.length, 1, 1 }, NativeTypeEnum.Float);
+
+    FloatBuffer buffer = FloatBuffer.wrap(matrix);
+    matrixCl.readFrom(buffer, true);
+
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("input", src);
+    parameters.put("output", dst);
+    parameters.put("mat", matrixCl);
+
+    boolean result = clke.execute(Kernels.class,
+                                  "affineTransforms.cl",
+                                  "affine",
+                                  parameters);
+
+    matrixCl.close();
+
+    return result;
+  }
+  /*
+    public static boolean affineTransform(CLKernelExecutor clke, ClearCLBuffer src, ClearCLBuffer dst, AffineTransform3D at) {
+        at = at.inverse();
+        float[] matrix = AffineTransform.matrixToFloatArray(at);
+        return affineTransform(clke, src, dst, matrix);
+    }
+    */
+
+  public static boolean affineTransform(CLKernelExecutor clke,
+                                        ClearCLImage src,
+                                        ClearCLImage dst,
+                                        float[] matrix)
+  {
+
+    ClearCLBuffer matrixCl = clke.createCLBuffer(new long[]
+    { matrix.length, 1, 1 }, NativeTypeEnum.Float);
+
+    FloatBuffer buffer = FloatBuffer.wrap(matrix);
+    matrixCl.readFrom(buffer, true);
+
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("input", src);
+    parameters.put("output", dst);
+    parameters.put("mat", matrixCl);
+
+    boolean result = clke.execute(Kernels.class,
+                                  "affineTransforms_interpolate.cl",
+                                  "affine_interpolate",
+                                  parameters);
+
+    matrixCl.close();
+
+    return result;
+  }
+
+  /*
+  public static boolean affineTransform(CLKernelExecutor clke, ClearCLImage src, ClearCLImage dst, AffineTransform3D at) {
+      at = at.inverse();
+      float[] matrix = AffineTransform.matrixToFloatArray(at);
+      return affineTransform(clke, src, dst, matrix);
+  }
+  */
+
+  public static boolean applyVectorfield(CLKernelExecutor clke,
+                                         ClearCLImage src,
+                                         ClearCLImage vectorX,
+                                         ClearCLImage vectorY,
+                                         ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("vectorX", vectorX);
+    parameters.put("vectorY", vectorY);
+
+    boolean result =
+                   clke.execute(Kernels.class,
+                                "deform_interpolate.cl",
+                                "deform_2d_interpolate",
+                                parameters);
+    return result;
+  }
+
+  public static boolean applyVectorfield(CLKernelExecutor clke,
+                                         ClearCLImage src,
+                                         ClearCLImage vectorX,
+                                         ClearCLImage vectorY,
+                                         ClearCLImage vectorZ,
+                                         ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("vectorX", vectorX);
+    parameters.put("vectorY", vectorY);
+    parameters.put("vectorZ", vectorZ);
+
+    boolean result =
+                   clke.execute(Kernels.class,
+                                "deform_interpolate.cl",
+                                "deform_3d_interpolate",
+                                parameters);
+    return result;
+  }
+
+  public static boolean applyVectorfield(CLKernelExecutor clke,
+                                         ClearCLBuffer src,
+                                         ClearCLBuffer vectorX,
+                                         ClearCLBuffer vectorY,
+                                         ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("vectorX", vectorX);
+    parameters.put("vectorY", vectorY);
+
+    boolean result =
+                   clke.execute(Kernels.class,
+                                "deform.cl",
+                                "deform_2d",
+                                parameters);
+    return result;
+  }
+
+  public static boolean applyVectorfield(CLKernelExecutor clke,
+                                         ClearCLBuffer src,
+                                         ClearCLBuffer vectorX,
+                                         ClearCLBuffer vectorY,
+                                         ClearCLBuffer vectorZ,
+                                         ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("vectorX", vectorX);
+    parameters.put("vectorY", vectorY);
+    parameters.put("vectorZ", vectorZ);
+
+    boolean result =
+                   clke.execute(Kernels.class,
+                                "deform.cl",
+                                "deform_3d",
+                                parameters);
+    return result;
+  }
+
+  /*
+  public static boolean automaticThreshold(CLKernelExecutor clke, ClearCLBuffer src, ClearCLBuffer dst, String userSelectedMethod) {
+      Float minimumGreyValue = 0f;
+      Float maximumGreyValue = 0f;
+      Integer numberOfBins = 256;
+  
+      if (src.getNativeType() == NativeTypeEnum.UnsignedByte) {
+          minimumGreyValue = 0f;
+          maximumGreyValue = 255f;
+      } else {
+          minimumGreyValue = null;
+          maximumGreyValue = null;
+      }
+  
+      return automaticThreshold(clke, src, dst, userSelectedMethod, minimumGreyValue, maximumGreyValue, 256);
+  }
+  
+  
+  public static boolean automaticThreshold(CLKernelExecutor clke, ClearCLBuffer src, ClearCLBuffer dst, String userSelectedMethod, Float minimumGreyValue, Float maximumGreyValue, Integer numberOfBins) {
+  
+      if (minimumGreyValue == null)
+      {
+          minimumGreyValue = new Double(Kernels.minimumOfAllPixels(clke, src)).floatValue();
+      }
+  
+      if (maximumGreyValue == null)
+      {
+          maximumGreyValue = new Double(Kernels.maximumOfAllPixels(clke, src)).floatValue();
+      }
+  
+  
+      ClearCLBuffer histogram = clke.createCLBuffer(new long[]{numberOfBins,1,1}, NativeTypeEnum.Float);
+      Kernels.fillHistogram(clke, src, histogram, minimumGreyValue, maximumGreyValue);
+      //releaseBuffers(args);
+  
+      //System.out.println("CL sum " + clke.op().sumPixels(histogram));
+  
+      // the histogram is written in args[1] which is supposed to be a one-dimensional image
+      ImagePlus histogramImp = clke.convert(histogram, ImagePlus.class);
+      histogram.close();
+  
+      // convert histogram
+      float[] determinedHistogram = (float[])(histogramImp.getProcessor().getPixels());
+      int[] convertedHistogram = new int[determinedHistogram.length];
+  
+      long sum = 0;
+      for (int i = 0; i < determinedHistogram.length; i++) {
+          convertedHistogram[i] = (int)determinedHistogram[i];
+          sum += convertedHistogram[i];
+      }
+      //System.out.println("Sum: " + sum);
+  
+  
+      String method = "Default";
+  
+      for (String choice : AutoThresholder.getMethods()) {
+          if (choice.toLowerCase().compareTo(userSelectedMethod.toLowerCase()) == 0) {
+              method = choice;
+          }
+      }
+      //System.out.println("Method: " + method);
+  
+      float threshold = new AutoThresholder().getThreshold(method, convertedHistogram);
+  
+      // math source https://github.com/imagej/ImageJA/blob/master/src/main/java/ij/process/ImageProcessor.java#L692
+      threshold = minimumGreyValue + ((threshold + 1.0f)/255.0f)*(maximumGreyValue-minimumGreyValue);
+  
+      //System.out.println("Threshold: " + threshold);
+  
+      Kernels.threshold(clke, src, dst, threshold);
+  
+      return true;
+  }
+  */
+
+  public static boolean argMaximumZProjection(CLKernelExecutor clke,
+                                              ClearCLImage src,
+                                              ClearCLImage dst_max,
+                                              ClearCLImage dst_arg)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst_max", dst_max);
+    parameters.put("dst_arg", dst_arg);
+
+    return clke.execute(Kernels.class,
+                        "projections.cl",
+                        "arg_max_project_3d_2d",
+                        parameters);
+  }
+
+  public static boolean argMaximumZProjection(CLKernelExecutor clke,
+                                              ClearCLBuffer src,
+                                              ClearCLBuffer dst_max,
+                                              ClearCLBuffer dst_arg)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst_max", dst_max);
+    parameters.put("dst_arg", dst_arg);
+
+    return clke.execute(Kernels.class,
+                        "projections.cl",
+                        "arg_max_project_3d_2d",
+                        parameters);
+  }
+
+  public static boolean binaryAnd(CLKernelExecutor clke,
+                                  ClearCLImage src1,
+                                  ClearCLImage src2,
+                                  ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src1", src1);
+    parameters.put("src2", src2);
+    parameters.put("dst", dst);
+
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "binary_and_" + src1.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean binaryAnd(CLKernelExecutor clke,
+                                  ClearCLBuffer src1,
+                                  ClearCLBuffer src2,
+                                  ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src1", src1);
+    parameters.put("src2", src2);
+    parameters.put("dst", dst);
+
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "binary_and_" + src1.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean binaryXOr(CLKernelExecutor clke,
+                                  ClearCLImage src1,
+                                  ClearCLImage src2,
+                                  ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src1", src1);
+    parameters.put("src2", src2);
+    parameters.put("dst", dst);
+
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "binary_xor_" + src1.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean binaryXOr(CLKernelExecutor clke,
+                                  ClearCLBuffer src1,
+                                  ClearCLBuffer src2,
+                                  ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src1", src1);
+    parameters.put("src2", src2);
+    parameters.put("dst", dst);
+
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "binary_xor_" + src1.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean binaryNot(CLKernelExecutor clke,
+                                  ClearCLImage src1,
+                                  ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src1", src1);
+    parameters.put("dst", dst);
+
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "binary_not_" + src1.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean binaryNot(CLKernelExecutor clke,
+                                  ClearCLBuffer src1,
+                                  ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src1", src1);
+    parameters.put("dst", dst);
+
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "binary_not_" + src1.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean binaryOr(CLKernelExecutor clke,
+                                 ClearCLImage src1,
+                                 ClearCLImage src2,
+                                 ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src1", src1);
+    parameters.put("src2", src2);
+    parameters.put("dst", dst);
+
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "binary_or_" + src1.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean binaryOr(CLKernelExecutor clke,
+                                 ClearCLBuffer src1,
+                                 ClearCLBuffer src2,
+                                 ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src1", src1);
+    parameters.put("src2", src2);
+    parameters.put("dst", dst);
+
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "binary_or_" + src1.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean blur(CLKernelExecutor clke,
+                             ClearCLImage src,
+                             ClearCLImage dst,
+                             Float blurSigmaX,
+                             Float blurSigmaY)
+  {
+    return executeSeparableKernel(clke,
+                                  src,
+                                  dst,
+                                  "blur.cl",
+                                  "gaussian_blur_sep_image"
+                                             + src.getDimension()
+                                             + "d",
+                                  sigmaToKernelSize(blurSigmaX),
+                                  sigmaToKernelSize(blurSigmaY),
+                                  sigmaToKernelSize(0),
+                                  blurSigmaX,
+                                  blurSigmaY,
+                                  0,
+                                  src.getDimension());
+  }
+
+  public static boolean blur(CLKernelExecutor clke,
+                             ClearCLImage src,
+                             ClearCLBuffer dst,
+                             Float blurSigmaX,
+                             Float blurSigmaY)
+  {
+    return executeSeparableKernel(clke,
+                                  src,
+                                  dst,
+                                  "blur.cl",
+                                  "gaussian_blur_sep_image"
+                                             + src.getDimension()
+                                             + "d",
+                                  sigmaToKernelSize(blurSigmaX),
+                                  sigmaToKernelSize(blurSigmaY),
+                                  sigmaToKernelSize(0),
+                                  blurSigmaX,
+                                  blurSigmaY,
+                                  0,
+                                  src.getDimension());
+  }
+
+  public static boolean blur(CLKernelExecutor clke,
+                             ClearCLBuffer src,
+                             ClearCLBuffer dst,
+                             Float blurSigmaX,
+                             Float blurSigmaY)
+  {
+    return executeSeparableKernel(clke,
+                                  src,
+                                  dst,
+                                  "blur.cl",
+                                  "gaussian_blur_sep_image"
+                                             + src.getDimension()
+                                             + "d",
+                                  sigmaToKernelSize(blurSigmaX),
+                                  sigmaToKernelSize(blurSigmaY),
+                                  sigmaToKernelSize(0),
+                                  blurSigmaX,
+                                  blurSigmaY,
+                                  0,
+                                  src.getDimension());
+  }
+
+  public static boolean blur(CLKernelExecutor clke,
+                             ClearCLImage src,
+                             ClearCLImage dst,
+                             Float blurSigmaX,
+                             Float blurSigmaY,
+                             Float blurSigmaZ)
+  {
+    return executeSeparableKernel(clke,
+                                  src,
+                                  dst,
+                                  "blur.cl",
+                                  "gaussian_blur_sep_image"
+                                             + src.getDimension()
+                                             + "d",
+                                  sigmaToKernelSize(blurSigmaX),
+                                  sigmaToKernelSize(blurSigmaY),
+                                  sigmaToKernelSize(blurSigmaZ),
+                                  blurSigmaX,
+                                  blurSigmaY,
+                                  blurSigmaZ,
+                                  src.getDimension());
+  }
+
+  public static boolean blur(CLKernelExecutor clke,
+                             ClearCLImage src,
+                             ClearCLBuffer dst,
+                             Float blurSigmaX,
+                             Float blurSigmaY,
+                             Float blurSigmaZ)
+  {
+    return executeSeparableKernel(clke,
+                                  src,
+                                  dst,
+                                  "blur.cl",
+                                  "gaussian_blur_sep_image"
+                                             + src.getDimension()
+                                             + "d",
+                                  sigmaToKernelSize(blurSigmaX),
+                                  sigmaToKernelSize(blurSigmaY),
+                                  sigmaToKernelSize(blurSigmaZ),
+                                  blurSigmaX,
+                                  blurSigmaY,
+                                  blurSigmaZ,
+                                  src.getDimension());
+  }
+
+  public static boolean blur(CLKernelExecutor clke,
+                             ClearCLBuffer src,
+                             ClearCLBuffer dst,
+                             Float blurSigmaX,
+                             Float blurSigmaY,
+                             Float blurSigmaZ)
+  {
+    return executeSeparableKernel(clke,
+                                  src,
+                                  dst,
+                                  "blur.cl",
+                                  "gaussian_blur_sep_image"
+                                             + src.getDimension()
+                                             + "d",
+                                  sigmaToKernelSize(blurSigmaX),
+                                  sigmaToKernelSize(blurSigmaY),
+                                  sigmaToKernelSize(blurSigmaZ),
+                                  blurSigmaX,
+                                  blurSigmaY,
+                                  blurSigmaZ,
+                                  src.getDimension());
+  }
+
+  public static boolean countNonZeroPixelsLocally(CLKernelExecutor clke,
+                                                  ClearCLBuffer src,
+                                                  ClearCLBuffer dst,
+                                                  Integer radiusX,
+                                                  Integer radiusY)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("Nx", radiusToKernelSize(radiusX));
+    parameters.put("Ny", radiusToKernelSize(radiusY));
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    return clke.execute(Kernels.class,
+                        "binaryCounting.cl",
+                        "count_nonzero_image2d",
+                        parameters);
+  }
+
+  public static boolean countNonZeroPixelsLocallySliceBySlice(CLKernelExecutor clke,
+                                                              ClearCLBuffer src,
+                                                              ClearCLBuffer dst,
+                                                              Integer radiusX,
+                                                              Integer radiusY)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("Nx", radiusToKernelSize(radiusX));
+    parameters.put("Ny", radiusToKernelSize(radiusY));
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    return clke.execute(Kernels.class,
+                        "binaryCounting.cl",
+                        "count_nonzero_slicewise_image3d",
+                        parameters);
+  }
+
+  public static boolean countNonZeroVoxelsLocally(CLKernelExecutor clke,
+                                                  ClearCLBuffer src,
+                                                  ClearCLBuffer dst,
+                                                  Integer radiusX,
+                                                  Integer radiusY,
+                                                  Integer radiusZ)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("Nx", radiusToKernelSize(radiusX));
+    parameters.put("Ny", radiusToKernelSize(radiusY));
+    parameters.put("Nz", radiusToKernelSize(radiusZ));
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    return clke.execute(Kernels.class,
+                        "binaryCounting.cl",
+                        "count_nonzero_image3d",
+                        parameters);
+  }
+
+  public static boolean countNonZeroPixelsLocally(CLKernelExecutor clke,
+                                                  ClearCLImage src,
+                                                  ClearCLImage dst,
+                                                  Integer radiusX,
+                                                  Integer radiusY)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("Nx", radiusToKernelSize(radiusX));
+    parameters.put("Ny", radiusToKernelSize(radiusY));
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    return clke.execute(Kernels.class,
+                        "binaryCounting.cl",
+                        "count_nonzero_image2d",
+                        parameters);
+  }
+
+  public static boolean countNonZeroPixelsLocallySliceBySlice(CLKernelExecutor clke,
+                                                              ClearCLImage src,
+                                                              ClearCLImage dst,
+                                                              Integer radiusX,
+                                                              Integer radiusY)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("Nx", radiusToKernelSize(radiusX));
+    parameters.put("Ny", radiusToKernelSize(radiusY));
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    return clke.execute(Kernels.class,
+                        "binaryCounting.cl",
+                        "count_nonzero_slicewise_image3d",
+                        parameters);
+  }
+
+  public static boolean countNonZeroVoxelsLocally(CLKernelExecutor clke,
+                                                  ClearCLImage src,
+                                                  ClearCLImage dst,
+                                                  Integer radiusX,
+                                                  Integer radiusY,
+                                                  Integer radiusZ)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("Nx", radiusToKernelSize(radiusX));
+    parameters.put("Ny", radiusToKernelSize(radiusY));
+    parameters.put("Nz", radiusToKernelSize(radiusZ));
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    return clke.execute(Kernels.class,
+                        "binaryCounting.cl",
+                        "count_nonzero_image3d",
+                        parameters);
+  }
+
+  private static boolean executeSeparableKernel(CLKernelExecutor clke,
+                                                Object src,
+                                                Object dst,
+                                                String clFilename,
+                                                String kernelname,
+                                                int kernelSizeX,
+                                                int kernelSizeY,
+                                                int kernelSizeZ,
+                                                float blurSigmaX,
+                                                float blurSigmaY,
+                                                float blurSigmaZ,
+                                                long dimensions)
+  {
+    int[] n = new int[]
+    { kernelSizeX, kernelSizeY, kernelSizeZ };
+    float[] blurSigma = new float[]
+    { blurSigmaX, blurSigmaY, blurSigmaZ };
+
+    Object temp;
+    if (src instanceof ClearCLBuffer)
+    {
+      temp = clke.createCLBuffer((ClearCLBuffer) src);
+    }
+    else if (src instanceof ClearCLImage)
+    {
+      temp = clke.createCLImage((ClearCLImage) src);
+    }
+    else
+    {
+      throw new IllegalArgumentException("Error: Wrong type of images in blurFast");
+    }
+
+    HashMap<String, Object> parameters = new HashMap<>();
+
+    if (blurSigma[0] > 0)
+    {
+      parameters.clear();
+      parameters.put("N", n[0]);
+      parameters.put("s", blurSigma[0]);
+      parameters.put("dim", 0);
+      parameters.put("src", src);
+      if (dimensions == 2)
+      {
+        parameters.put("dst", temp);
+      }
+      else
+      {
+        parameters.put("dst", dst);
+      }
+      clke.execute(Kernels.class, clFilename, kernelname, parameters);
+    }
+    else
+    {
+      if (dimensions == 2)
+      {
+        Kernels.copyInternal(clke, src, temp, 2, 2);
+      }
+      else
+      {
+        Kernels.copyInternal(clke, src, dst, 3, 3);
+      }
+    }
+
+    if (blurSigma[1] > 0)
+    {
+      parameters.clear();
+      parameters.put("N", n[1]);
+      parameters.put("s", blurSigma[1]);
+      parameters.put("dim", 1);
+      if (dimensions == 2)
+      {
+        parameters.put("src", temp);
+        parameters.put("dst", dst);
+      }
+      else
+      {
+        parameters.put("src", dst);
+        parameters.put("dst", temp);
+      }
+      clke.execute(Kernels.class, clFilename, kernelname, parameters);
+    }
+    else
+    {
+      if (dimensions == 2)
+      {
+        Kernels.copyInternal(clke, temp, dst, 2, 2);
+      }
+      else
+      {
+        Kernels.copyInternal(clke, dst, temp, 3, 3);
+      }
+    }
+
+    if (dimensions == 3)
+    {
+      if (blurSigma[2] > 0)
+      {
+        parameters.clear();
+        parameters.put("N", n[2]);
+        parameters.put("s", blurSigma[2]);
+        parameters.put("dim", 2);
+        parameters.put("src", temp);
+        parameters.put("dst", dst);
+        clke.execute(Kernels.class,
+                     clFilename,
+                     kernelname,
+                     parameters);
+      }
+      else
+      {
+        Kernels.copyInternal(clke, temp, dst, 3, 3);
+      }
+    }
+
+    if (temp instanceof ClearCLBuffer)
+    {
+      ((ClearCLBuffer) temp).close();
+    }
+    else if (temp instanceof ClearCLImage)
+    {
+      ((ClearCLImage) temp).close();
+    }
+
+    return true;
+  }
+
+  public static boolean blurSliceBySlice(CLKernelExecutor clke,
+                                         ClearCLImage src,
+                                         ClearCLImage dst,
+                                         Integer kernelSizeX,
+                                         Integer kernelSizeY,
+                                         Float sigmaX,
+                                         Float sigmaY)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+    parameters.put("sx", sigmaX);
+    parameters.put("sy", sigmaY);
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    return clke.execute(Kernels.class,
+                        "blur.cl",
+                        "gaussian_blur_slicewise_image3d",
+                        parameters);
+  }
+
+  public static boolean blurSliceBySlice(CLKernelExecutor clke,
+                                         ClearCLBuffer src,
+                                         ClearCLBuffer dst,
+                                         int kernelSizeX,
+                                         int kernelSizeY,
+                                         float sigmaX,
+                                         float sigmaY)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+    parameters.put("sx", sigmaX);
+    parameters.put("sy", sigmaY);
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    return clke.execute(Kernels.class,
+                        "blur.cl",
+                        "gaussian_blur_slicewise_image3d",
+                        parameters);
+  }
+
+  /*
+  public static double[] centerOfMass(CLKernelExecutor clke, ClearCLBuffer input) {
+      ClearCLBuffer multipliedWithCoordinate = clke.create(input.getDimensions(), NativeTypeEnum.Float);
+      double sum = sumPixels(clke, input);
+      double[] resultCenterOfMass;
+      if (input.getDimension() > 2L && input.getDepth() > 1L) {
+          resultCenterOfMass = new double[3];
+      } else {
+          resultCenterOfMass = new double[2];
+      }
+  
+      multiplyImageAndCoordinate(clke, input, multipliedWithCoordinate, 0);
+      double sumX = sumPixels(clke, multipliedWithCoordinate);
+      resultCenterOfMass[0] = sumX / sum;
+      multiplyImageAndCoordinate(clke, input, multipliedWithCoordinate, 1);
+      double sumY = sumPixels(clke, multipliedWithCoordinate);
+      resultCenterOfMass[1] = sumY / sum;
+      if (input.getDimension() > 2L && input.getDepth() > 1L) {
+          multiplyImageAndCoordinate(clke, input, multipliedWithCoordinate, 2);
+          double sumZ = sumPixels(clke, multipliedWithCoordinate);
+          resultCenterOfMass[2] = sumZ / sum;
+      }
+  
+      multipliedWithCoordinate.close();
+      return resultCenterOfMass;
+  }
+  
+  
+  public static double[] centerOfMass(CLKernelExecutor clke, ClearCLImage input) {
+      ClearCLImage multipliedWithCoordinate = clke.create(input.getDimensions(), ImageChannelDataType.Float);
+      double sum = sumPixels(clke, input);
+      double[] resultCenterOfMass;
+      if (input.getDimension() > 2L && input.getDepth() > 1L) {
+          resultCenterOfMass = new double[3];
+      } else {
+          resultCenterOfMass = new double[2];
+      }
+  
+      multiplyImageAndCoordinate(clke, input, multipliedWithCoordinate, 0);
+      double sumX = sumPixels(clke, multipliedWithCoordinate);
+      resultCenterOfMass[0] = sumX / sum;
+      multiplyImageAndCoordinate(clke, input, multipliedWithCoordinate, 1);
+      double sumY = sumPixels(clke, multipliedWithCoordinate);
+      resultCenterOfMass[1] = sumY / sum;
+      if (input.getDimension() > 2L && input.getDepth() > 1L) {
+          multiplyImageAndCoordinate(clke, input, multipliedWithCoordinate, 2);
+          double sumZ = sumPixels(clke, multipliedWithCoordinate);
+          resultCenterOfMass[2] = sumZ / sum;
+      }
+  
+      multipliedWithCoordinate.close();
+      return resultCenterOfMass;
+  }
+  */
+
+  public static boolean copy(CLKernelExecutor clke,
+                             ClearCLImage src,
+                             ClearCLBuffer dst)
+  {
+    return copyInternal(clke,
+                        src,
+                        dst,
+                        src.getDimension(),
+                        dst.getDimension());
+  }
+
+  private static boolean copyInternal(CLKernelExecutor clke,
+                                      Object src,
+                                      Object dst,
+                                      long srcNumberOfDimensions,
+                                      long dstNumberOfDimensions)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    if (!checkDimensions(srcNumberOfDimensions,
+                         dstNumberOfDimensions))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+    return clke.execute(Kernels.class,
+                        "duplication.cl",
+                        "copy_" + srcNumberOfDimensions + "d",
+                        parameters);
+  }
+
+  public static boolean copy(CLKernelExecutor clke,
+                             ClearCLBuffer src,
+                             ClearCLImage dst)
+  {
+    return copyInternal(clke,
+                        src,
+                        dst,
+                        src.getDimension(),
+                        dst.getDimension());
+  }
+
+  public static boolean copy(CLKernelExecutor clke,
+                             ClearCLImage src,
+                             ClearCLImage dst)
+  {
+    return copyInternal(clke,
+                        src,
+                        dst,
+                        src.getDimension(),
+                        dst.getDimension());
+  }
+
+  public static boolean copy(CLKernelExecutor clke,
+                             ClearCLBuffer src,
+                             ClearCLBuffer dst)
+  {
+    return copyInternal(clke,
+                        src,
+                        dst,
+                        src.getDimension(),
+                        dst.getDimension());
+  }
+
+  public static boolean copySlice(CLKernelExecutor clke,
+                                  ClearCLImage src,
+                                  ClearCLImage dst,
+                                  Integer planeIndex)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("slice", planeIndex);
+    if (src.getDimension() == 2 && dst.getDimension() == 3)
+    {
+      return clke.execute(Kernels.class,
+                          "duplication.cl",
+                          "putSliceInStack",
+                          parameters);
+    }
+    else if (src.getDimension() == 3 && dst.getDimension() == 2)
+    {
+      return clke.execute(Kernels.class,
+                          "duplication.cl",
+                          "copySlice",
+                          parameters);
+    }
+    else
+    {
+      throw new IllegalArgumentException("Images have wrong dimension. Must be 3D->2D or 2D->3D.");
+    }
+  }
+
+  public static boolean copySlice(CLKernelExecutor clke,
+                                  ClearCLBuffer src,
+                                  ClearCLBuffer dst,
+                                  Integer planeIndex)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("slice", planeIndex);
+    // return clke.execute(Kernels.class, "duplication.cl", "copySlice",
+    // parameters);
+    if (src.getDimension() == 2 && dst.getDimension() == 3)
+    {
+      return clke.execute(Kernels.class,
+                          "duplication.cl",
+                          "putSliceInStack",
+                          parameters);
+    }
+    else if (src.getDimension() == 3 && dst.getDimension() == 2)
+    {
+      return clke.execute(Kernels.class,
+                          "duplication.cl",
+                          "copySlice",
+                          parameters);
+    }
+    else
+    {
+      throw new IllegalArgumentException("Images have wrong dimension. Must be 3D->2D or 2D->3D.");
+    }
+  }
+
+  public static boolean crop(CLKernelExecutor clke,
+                             ClearCLImage src,
+                             ClearCLImage dst,
+                             Integer startX,
+                             Integer startY,
+                             Integer startZ)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("start_x", startX);
+    parameters.put("start_y", startY);
+    parameters.put("start_z", startZ);
+    return clke.execute(Kernels.class,
+                        "duplication.cl",
+                        "crop_3d",
+                        parameters);
+  }
+
+  public static boolean crop(CLKernelExecutor clke,
+                             ClearCLImage src,
+                             ClearCLImage dst,
+                             Integer startX,
+                             Integer startY)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("start_x", startX);
+    parameters.put("start_y", startY);
+    return clke.execute(Kernels.class,
+                        "duplication.cl",
+                        "crop_2d",
+                        parameters);
+  }
+
+  public static boolean crop(CLKernelExecutor clke,
+                             ClearCLBuffer src,
+                             ClearCLBuffer dst,
+                             Integer startX,
+                             Integer startY,
+                             Integer startZ)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("start_x", startX);
+    parameters.put("start_y", startY);
+    parameters.put("start_z", startZ);
+    return clke.execute(Kernels.class,
+                        "duplication.cl",
+                        "crop_3d",
+                        parameters);
+  }
+
+  public static boolean crop(CLKernelExecutor clke,
+                             ClearCLBuffer src,
+                             ClearCLBuffer dst,
+                             Integer startX,
+                             Integer startY)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("start_x", startX);
+    parameters.put("start_y", startY);
+    return clke.execute(Kernels.class,
+                        "duplication.cl",
+                        "crop_2d",
+                        parameters);
+  }
+
+  public static boolean crossCorrelation(CLKernelExecutor clke,
+                                         ClearCLBuffer src1,
+                                         ClearCLBuffer meanSrc1,
+                                         ClearCLBuffer src2,
+                                         ClearCLBuffer meanSrc2,
+                                         ClearCLBuffer dst,
+                                         int radius,
+                                         int deltaPos,
+                                         int dimension)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src1", src1);
+    parameters.put("mean_src1", meanSrc1);
+    parameters.put("src2", src2);
+    parameters.put("mean_src2", meanSrc2);
+    parameters.put("dst", dst);
+    parameters.put("radius", radius);
+    parameters.put("i", deltaPos);
+    parameters.put("dimension", dimension);
+    return clke.execute(Kernels.class,
+                        "cross_correlation.cl",
+                        "cross_correlation_3d",
+                        parameters);
+  }
+
+  public static boolean crossCorrelation(CLKernelExecutor clke,
+                                         ClearCLImage src1,
+                                         ClearCLImage meanSrc1,
+                                         ClearCLImage src2,
+                                         ClearCLImage meanSrc2,
+                                         ClearCLImage dst,
+                                         int radius,
+                                         int deltaPos,
+                                         int dimension)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src1", src1);
+    parameters.put("mean_src1", meanSrc1);
+    parameters.put("src2", src2);
+    parameters.put("mean_src2", meanSrc2);
+    parameters.put("dst", dst);
+    parameters.put("radius", radius);
+    parameters.put("i", deltaPos);
+    parameters.put("dimension", dimension);
+    return clke.execute(Kernels.class,
+                        "cross_correlation.cl",
+                        "cross_correlation_3d",
+                        parameters);
+  }
+
+  public static boolean detectMaximaBox(CLKernelExecutor clke,
+                                        ClearCLImage src,
+                                        ClearCLImage dst,
+                                        Integer radius)
+  {
+    return detectOptima(clke, src, dst, radius, true);
+  }
+
+  public static boolean detectMaximaBox(CLKernelExecutor clke,
+                                        ClearCLBuffer src,
+                                        ClearCLBuffer dst,
+                                        Integer radius)
+  {
+    return detectOptima(clke, src, dst, radius, true);
+  }
+
+  public static boolean detectMaximaSliceBySliceBox(CLKernelExecutor clke,
+                                                    ClearCLImage src,
+                                                    ClearCLImage dst,
+                                                    Integer radius)
+  {
+    return detectOptimaSliceBySlice(clke, src, dst, radius, true);
+  }
+
+  public static boolean detectMaximaSliceBySliceBox(CLKernelExecutor clke,
+                                                    ClearCLBuffer src,
+                                                    ClearCLBuffer dst,
+                                                    Integer radius)
+  {
+    return detectOptimaSliceBySlice(clke, src, dst, radius, true);
+  }
+
+  public static boolean detectMinimaBox(CLKernelExecutor clke,
+                                        ClearCLImage src,
+                                        ClearCLImage dst,
+                                        Integer radius)
+  {
+    return detectOptima(clke, src, dst, radius, false);
+  }
+
+  public static boolean detectMinimaBox(CLKernelExecutor clke,
+                                        ClearCLBuffer src,
+                                        ClearCLBuffer dst,
+                                        Integer radius)
+  {
+    return detectOptima(clke, src, dst, radius, false);
+  }
+
+  public static boolean detectMinimaSliceBySliceBox(CLKernelExecutor clke,
+                                                    ClearCLImage src,
+                                                    ClearCLImage dst,
+                                                    Integer radius)
+  {
+    return detectOptimaSliceBySlice(clke, src, dst, radius, false);
+  }
+
+  public static boolean detectMinimaSliceBySliceBox(CLKernelExecutor clke,
+                                                    ClearCLBuffer src,
+                                                    ClearCLBuffer dst,
+                                                    Integer radius)
+  {
+    return detectOptimaSliceBySlice(clke, src, dst, radius, false);
+  }
+
+  public static boolean detectOptima(CLKernelExecutor clke,
+                                     ClearCLImage src,
+                                     ClearCLImage dst,
+                                     Integer radius,
+                                     Boolean detectMaxima)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("radius", radius);
+    parameters.put("detect_maxima", detectMaxima ? 1 : 0);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (detectOptima)");
+    }
+    return clke.execute(Kernels.class,
+                        "detection.cl",
+                        "detect_local_optima_" + src.getDimension()
+                                        + "d",
+                        parameters);
+  }
+
+  public static boolean detectOptima(CLKernelExecutor clke,
+                                     ClearCLBuffer src,
+                                     ClearCLBuffer dst,
+                                     Integer radius,
+                                     Boolean detectMaxima)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("radius", radius);
+    parameters.put("detect_maxima", detectMaxima ? 1 : 0);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (detectOptima)");
+    }
+    return clke.execute(Kernels.class,
+                        "detection.cl",
+                        "detect_local_optima_" + src.getDimension()
+                                        + "d",
+                        parameters);
+  }
+
+  public static boolean detectOptimaSliceBySlice(CLKernelExecutor clke,
+                                                 ClearCLImage src,
+                                                 ClearCLImage dst,
+                                                 Integer radius,
+                                                 Boolean detectMaxima)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("radius", radius);
+    parameters.put("detect_maxima", detectMaxima ? 1 : 0);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (detectOptima)");
+    }
+    return clke.execute(Kernels.class,
+                        "detection.cl",
+                        "detect_local_optima_" + src.getDimension()
+                                        + "d_slice_by_slice",
+                        parameters);
+  }
+
+  public static boolean detectOptimaSliceBySlice(CLKernelExecutor clke,
+                                                 ClearCLBuffer src,
+                                                 ClearCLBuffer dst,
+                                                 Integer radius,
+                                                 Boolean detectMaxima)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("radius", radius);
+    parameters.put("detect_maxima", detectMaxima ? 1 : 0);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (detectOptima)");
+    }
+    return clke.execute(Kernels.class,
+                        "detection.cl",
+                        "detect_local_optima_" + src.getDimension()
+                                        + "d_slice_by_slice",
+                        parameters);
+  }
+
+  public static boolean differenceOfGaussian(CLKernelExecutor clke,
+                                             ClearCLImage src,
+                                             ClearCLImage dst,
+                                             Integer radius,
+                                             Float sigmaMinuend,
+                                             Float sigmaSubtrahend)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("radius", radius);
+    parameters.put("sigma_minuend", sigmaMinuend);
+    parameters.put("sigma_subtrahend", sigmaSubtrahend);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+    return clke.execute(Kernels.class,
+                        "differenceOfGaussian.cl",
+                        "subtract_convolved_images_"
+                                                   + src.getDimension()
+                                                   + "d_fast",
+                        parameters);
+  }
+
+  public static boolean differenceOfGaussianSliceBySlice(CLKernelExecutor clke,
+                                                         ClearCLImage src,
+                                                         ClearCLImage dst,
+                                                         Integer radius,
+                                                         Float sigmaMinuend,
+                                                         Float sigmaSubtrahend)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("radius", radius);
+    parameters.put("sigma_minuend", sigmaMinuend);
+    parameters.put("sigma_subtrahend", sigmaSubtrahend);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+    return clke.execute(Kernels.class,
+                        "differenceOfGaussian.cl",
+                        "subtract_convolved_images_"
+                                                   + src.getDimension()
+                                                   + "d_slice_by_slice",
+                        parameters);
+  }
+
+  public static boolean dilateBox(CLKernelExecutor clke,
+                                  ClearCLImage src,
+                                  ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "dilate_box_neighborhood_"
+                                               + src.getDimension()
+                                               + "d",
+                        parameters);
+  }
+
+  public static boolean dilateBox(CLKernelExecutor clke,
+                                  ClearCLBuffer src,
+                                  ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "dilate_box_neighborhood_"
+                                               + src.getDimension()
+                                               + "d",
+                        parameters);
+  }
+
+  public static boolean dilateBoxSliceBySlice(CLKernelExecutor clke,
+                                              ClearCLImage src,
+                                              ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "dilate_box_neighborhood_slice_by_slice",
+                        parameters);
+  }
+
+  public static boolean dilateBoxSliceBySlice(CLKernelExecutor clke,
+                                              ClearCLBuffer src,
+                                              ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "dilate_box_neighborhood_slice_by_slice",
+                        parameters);
+  }
+
+  public static boolean dilateSphere(CLKernelExecutor clke,
+                                     ClearCLImage src,
+                                     ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "dilate_diamond_neighborhood_"
+                                               + src.getDimension()
+                                               + "d",
+                        parameters);
+  }
+
+  public static boolean dilateSphere(CLKernelExecutor clke,
+                                     ClearCLBuffer src,
+                                     ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "dilate_diamond_neighborhood_"
+                                               + src.getDimension()
+                                               + "d",
+                        parameters);
+  }
+
+  public static boolean dilateSphereSliceBySlice(CLKernelExecutor clke,
+                                                 ClearCLImage src,
+                                                 ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "dilate_diamond_neighborhood_slice_by_slice",
+                        parameters);
+  }
+
+  public static boolean dilateSphereSliceBySlice(CLKernelExecutor clke,
+                                                 ClearCLBuffer src,
+                                                 ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "dilate_diamond_neighborhood_slice_by_slice",
+                        parameters);
+  }
+
+  public static boolean divideImages(CLKernelExecutor clke,
+                                     ClearCLImage src,
+                                     ClearCLImage src1,
+                                     ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("src1", src1);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(),
+                         src1.getDimension(),
+                         dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (addImageAndScalar)");
+    }
+
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "dividePixelwise_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean divideImages(CLKernelExecutor clke,
+                                     ClearCLBuffer src,
+                                     ClearCLBuffer src1,
+                                     ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("src1", src1);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(),
+                         src1.getDimension(),
+                         dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (addImageAndScalar)");
+    }
+
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "dividePixelwise_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean downsample(CLKernelExecutor clke,
+                                   ClearCLImage src,
+                                   ClearCLImage dst,
+                                   Float factorX,
+                                   Float factorY,
+                                   Float factorZ)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("factor_x", 1.f / factorX);
+    parameters.put("factor_y", 1.f / factorY);
+    parameters.put("factor_z", 1.f / factorZ);
+    return clke.execute(Kernels.class,
+                        "downsampling.cl",
+                        "downsample_3d_nearest",
+                        parameters);
+  }
+
+  public static boolean downsample(CLKernelExecutor clke,
+                                   ClearCLBuffer src,
+                                   ClearCLBuffer dst,
+                                   Float factorX,
+                                   Float factorY,
+                                   Float factorZ)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("factor_x", 1.f / factorX);
+    parameters.put("factor_y", 1.f / factorY);
+    parameters.put("factor_z", 1.f / factorZ);
+    return clke.execute(Kernels.class,
+                        "downsampling.cl",
+                        "downsample_3d_nearest",
+                        parameters);
+  }
+
+  public static boolean downsample(CLKernelExecutor clke,
+                                   ClearCLImage src,
+                                   ClearCLImage dst,
+                                   Float factorX,
+                                   Float factorY)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("factor_x", 1.f / factorX);
+    parameters.put("factor_y", 1.f / factorY);
+    return clke.execute(Kernels.class,
+                        "downsampling.cl",
+                        "downsample_2d_nearest",
+                        parameters);
+  }
+
+  public static boolean downsample(CLKernelExecutor clke,
+                                   ClearCLBuffer src,
+                                   ClearCLBuffer dst,
+                                   Float factorX,
+                                   Float factorY)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("factor_x", 1.f / factorX);
+    parameters.put("factor_y", 1.f / factorY);
+    return clke.execute(Kernels.class,
+                        "downsampling.cl",
+                        "downsample_2d_nearest",
+                        parameters);
+  }
+
+  public static boolean downsampleSliceBySliceHalfMedian(CLKernelExecutor clke,
+                                                         ClearCLImage src,
+                                                         ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    return clke.execute(Kernels.class,
+                        "downsampling.cl",
+                        "downsample_xy_by_half_median",
+                        parameters);
+  }
+
+  public static boolean downsampleSliceBySliceHalfMedian(CLKernelExecutor clke,
+                                                         ClearCLBuffer src,
+                                                         ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    return clke.execute(Kernels.class,
+                        "downsampling.cl",
+                        "downsample_xy_by_half_median",
+                        parameters);
+  }
+
+  public static boolean erodeSphere(CLKernelExecutor clke,
+                                    ClearCLImage src,
+                                    ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "erode_diamond_neighborhood_"
+                                               + src.getDimension()
+                                               + "d",
+                        parameters);
+  }
+
+  public static boolean erodeSphere(CLKernelExecutor clke,
+                                    ClearCLBuffer src,
+                                    ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "erode_diamond_neighborhood_"
+                                               + src.getDimension()
+                                               + "d",
+                        parameters);
+  }
+
+  public static boolean erodeSphereSliceBySlice(CLKernelExecutor clke,
+                                                ClearCLImage src,
+                                                ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "erode_diamond_neighborhood_slice_by_slice",
+                        parameters);
+  }
+
+  public static boolean erodeSphereSliceBySlice(CLKernelExecutor clke,
+                                                ClearCLBuffer src,
+                                                ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "erode_diamond_neighborhood_slice_by_slice",
+                        parameters);
+  }
+
+  public static boolean erodeBox(CLKernelExecutor clke,
+                                 ClearCLImage src,
+                                 ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "erode_box_neighborhood_" + src.getDimension()
+                                               + "d",
+                        parameters);
+  }
+
+  public static boolean erodeBox(CLKernelExecutor clke,
+                                 ClearCLBuffer src,
+                                 ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "erode_box_neighborhood_" + src.getDimension()
+                                               + "d",
+                        parameters);
+  }
+
+  public static boolean erodeBoxSliceBySlice(CLKernelExecutor clke,
+                                             ClearCLImage src,
+                                             ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "erode_box_neighborhood_slice_by_slice",
+                        parameters);
+  }
+
+  public static boolean erodeBoxSliceBySlice(CLKernelExecutor clke,
+                                             ClearCLBuffer src,
+                                             ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+
+    return clke.execute(Kernels.class,
+                        "binaryProcessing.cl",
+                        "erode_box_neighborhood_slice_by_slice",
+                        parameters);
+  }
+
+  public static boolean fillHistogram(CLKernelExecutor clke,
+                                      ClearCLBuffer src,
+                                      ClearCLBuffer dstHistogram,
+                                      Float minimumGreyValue,
+                                      Float maximumGreyValue)
+  {
+
+    int stepSizeX = 1;
+    int stepSizeY = 1;
+    int stepSizeZ = 1;
+
+    long[] globalSizes = new long[]
+    { src.getHeight() / stepSizeZ, 1, 1 };
+
+    long numberOfPartialHistograms = globalSizes[0] * globalSizes[1]
+                                     * globalSizes[2];
+    long[] histogramBufferSize = new long[]
+    { dstHistogram.getWidth(), 1, numberOfPartialHistograms };
+
+    long timeStamp = System.currentTimeMillis();
+
+    // allocate memory for partial histograms
+    ClearCLBuffer partialHistograms =
+                                    clke.createCLBuffer(histogramBufferSize,
+                                                        dstHistogram.getNativeType());
+
+    //
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst_histogram", partialHistograms);
+    parameters.put("minimum", minimumGreyValue);
+    parameters.put("maximum", maximumGreyValue);
+    parameters.put("step_size_x", stepSizeX);
+    parameters.put("step_size_y", stepSizeY);
+    if (src.getDimension() > 2)
+    {
+      parameters.put("step_size_z", stepSizeZ);
+    }
+    clke.execute(Kernels.class,
+                 "histogram.cl",
+                 "histogram_image_" + src.getDimension() + "d",
+                 globalSizes,
+                 parameters);
+
+    Kernels.sumZProjection(clke, partialHistograms, dstHistogram);
+    // IJ.log("Histogram generation took " + (System.currentTimeMillis() -
+    // timeStamp) + " msec");
+
+    partialHistograms.close();
+    return true;
+  }
+
+  public static boolean gradientX(CLKernelExecutor clke,
+                                  ClearCLBuffer src,
+                                  ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+    return clke.execute(Kernels.class,
+                        "neighbors.cl",
+                        "gradientX_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean gradientY(CLKernelExecutor clke,
+                                  ClearCLBuffer src,
+                                  ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+    return clke.execute(Kernels.class,
+                        "neighbors.cl",
+                        "gradientY_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean gradientZ(CLKernelExecutor clke,
+                                  ClearCLBuffer src,
+                                  ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+    return clke.execute(Kernels.class,
+                        "neighbors.cl",
+                        "gradientZ_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean gradientX(CLKernelExecutor clke,
+                                  ClearCLImage src,
+                                  ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+    return clke.execute(Kernels.class,
+                        "neighbors.cl",
+                        "gradientX_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean gradientY(CLKernelExecutor clke,
+                                  ClearCLImage src,
+                                  ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+    return clke.execute(Kernels.class,
+                        "neighbors.cl",
+                        "gradientY_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean gradientZ(CLKernelExecutor clke,
+                                  ClearCLImage src,
+                                  ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (copy)");
+    }
+    return clke.execute(Kernels.class,
+                        "neighbors.cl",
+                        "gradientZ_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  /*
+  public static float[] histogram(CLKernelExecutor clke, ClearCLBuffer image, Float minGreyValue, Float maxGreyValue, Integer numberOfBins) {
+      ClearCLBuffer histogram = clke.createCLBuffer(new long[]{numberOfBins, 1, 1}, NativeTypeEnum.Float);
+  
+      if (minGreyValue == null) {
+          minGreyValue = new Double(Kernels.minimumOfAllPixels(clke, image)).floatValue();
+      }
+      if (maxGreyValue == null) {
+          maxGreyValue = new Double(Kernels.maximumOfAllPixels(clke, image)).floatValue();
+      }
+  
+      Kernels.fillHistogram(clke, image, histogram, minGreyValue, maxGreyValue);
+  
+      ImagePlus histogramImp = clke.convert(histogram, ImagePlus.class);
+      histogram.close();
+  
+      float[] determinedHistogram = (float[])(histogramImp.getProcessor().getPixels());
+      return determinedHistogram;
+  }
+  */
+
+  public static boolean flip(CLKernelExecutor clke,
+                             ClearCLImage src,
+                             ClearCLImage dst,
+                             Boolean flipx,
+                             Boolean flipy,
+                             Boolean flipz)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("flipx", flipx ? 1 : 0);
+    parameters.put("flipy", flipy ? 1 : 0);
+    parameters.put("flipz", flipz ? 1 : 0);
+    return clke.execute(Kernels.class,
+                        "flip.cl",
+                        "flip_3d",
+                        parameters);
+  }
+
+  public static boolean flip(CLKernelExecutor clke,
+                             ClearCLImage src,
+                             ClearCLImage dst,
+                             Boolean flipx,
+                             Boolean flipy)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("flipx", flipx ? 1 : 0);
+    parameters.put("flipy", flipy ? 1 : 0);
+    return clke.execute(Kernels.class,
+                        "flip.cl",
+                        "flip_2d",
+                        parameters);
+  }
+
+  public static boolean flip(CLKernelExecutor clke,
+                             ClearCLBuffer src,
+                             ClearCLBuffer dst,
+                             Boolean flipx,
+                             Boolean flipy,
+                             Boolean flipz)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("flipx", flipx ? 1 : 0);
+    parameters.put("flipy", flipy ? 1 : 0);
+    parameters.put("flipz", flipz ? 1 : 0);
+    return clke.execute(Kernels.class,
+                        "flip.cl",
+                        "flip_3d",
+                        parameters);
+  }
+
+  public static boolean flip(CLKernelExecutor clke,
+                             ClearCLBuffer src,
+                             ClearCLBuffer dst,
+                             Boolean flipx,
+                             Boolean flipy)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("flipx", flipx ? 1 : 0);
+    parameters.put("flipy", flipy ? 1 : 0);
+    return clke.execute(Kernels.class,
+                        "flip.cl",
+                        "flip_2d",
+                        parameters);
+  }
+
+  public static boolean invert(CLKernelExecutor clke,
+                               ClearCLImage input3d,
+                               ClearCLImage output3d)
+  {
+    return multiplyImageAndScalar(clke, input3d, output3d, -1f);
+  }
+
+  public static boolean invert(CLKernelExecutor clke,
+                               ClearCLBuffer input3d,
+                               ClearCLBuffer output3d)
+  {
+    return multiplyImageAndScalar(clke, input3d, output3d, -1f);
+  }
+
+  public static boolean localThreshold(CLKernelExecutor clke,
+                                       ClearCLImage src,
+                                       ClearCLImage dst,
+                                       ClearCLImage threshold)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+
+    parameters.clear();
+    parameters.put("local_threshold", threshold);
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (addImageAndScalar)");
+    }
+
+    return clke.execute(Kernels.class,
+                        "thresholding.cl",
+                        "apply_local_threshold_" + src.getDimension()
+                                           + "d",
+                        parameters);
+  }
+
+  public static boolean localThreshold(CLKernelExecutor clke,
+                                       ClearCLBuffer src,
+                                       ClearCLBuffer dst,
+                                       ClearCLBuffer threshold)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+
+    parameters.clear();
+    parameters.put("local_threshold", threshold);
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (addImageAndScalar)");
+    }
+
+    return clke.execute(Kernels.class,
+                        "thresholding.cl",
+                        "apply_local_threshold_" + src.getDimension()
+                                           + "d",
+                        parameters);
+  }
+
+  public static boolean mask(CLKernelExecutor clke,
+                             ClearCLImage src,
+                             ClearCLImage mask,
+                             ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("mask", mask);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (mask)");
+    }
+    return clke.execute(Kernels.class,
+                        "mask.cl",
+                        "mask_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean mask(CLKernelExecutor clke,
+                             ClearCLBuffer src,
+                             ClearCLBuffer mask,
+                             ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("mask", mask);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (mask)");
+    }
+    return clke.execute(Kernels.class,
+                        "mask.cl",
+                        "mask_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean maskStackWithPlane(CLKernelExecutor clke,
+                                           ClearCLImage src,
+                                           ClearCLImage mask,
+                                           ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("mask", mask);
+    parameters.put("dst", dst);
+
+    return clke.execute(Kernels.class,
+                        "mask.cl",
+                        "maskStackWithPlane",
+                        parameters);
+  }
+
+  public static boolean maskStackWithPlane(CLKernelExecutor clke,
+                                           ClearCLBuffer src,
+                                           ClearCLBuffer mask,
+                                           ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("mask", mask);
+    parameters.put("dst", dst);
+
+    return clke.execute(Kernels.class,
+                        "mask.cl",
+                        "maskStackWithPlane",
+                        parameters);
+  }
+
+  public static boolean maximumSphere(CLKernelExecutor clke,
+                                      ClearCLImage src,
+                                      ClearCLImage dst,
+                                      Integer kernelSizeX,
+                                      Integer kernelSizeY)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "maximum_image2d",
+                        parameters);
+  }
+
+  public static boolean maximumSphere(CLKernelExecutor clke,
+                                      ClearCLBuffer src,
+                                      ClearCLBuffer dst,
+                                      Integer kernelSizeX,
+                                      Integer kernelSizeY)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "maximum_image2d",
+                        parameters);
+  }
+
+  public static boolean maximumSphere(CLKernelExecutor clke,
+                                      ClearCLImage src,
+                                      ClearCLImage dst,
+                                      Integer kernelSizeX,
+                                      Integer kernelSizeY,
+                                      Integer kernelSizeZ)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+    parameters.put("Nz", kernelSizeZ);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "maximum_image3d",
+                        parameters);
+  }
+
+  public static boolean maximumSphere(CLKernelExecutor clke,
+                                      ClearCLBuffer src,
+                                      ClearCLBuffer dst,
+                                      Integer kernelSizeX,
+                                      Integer kernelSizeY,
+                                      Integer kernelSizeZ)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+    parameters.put("Nz", kernelSizeZ);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "maximum_image3d",
+                        parameters);
+  }
+
+  @Deprecated
+  public static boolean maximumIJ(CLKernelExecutor clke,
+                                  ClearCLImage src,
+                                  ClearCLImage dst,
+                                  Integer radius)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("radius", radius);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "maximum_image2d_ij",
+                        parameters);
+  }
+
+  @Deprecated
+  public static boolean maximumIJ(CLKernelExecutor clke,
+                                  ClearCLBuffer src,
+                                  ClearCLBuffer dst,
+                                  Integer radius)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("radius", radius);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "maximum_image2d_ij",
+                        parameters);
+  }
+
+  public static boolean maximumSliceBySliceSphere(CLKernelExecutor clke,
+                                                  ClearCLImage src,
+                                                  ClearCLImage dst,
+                                                  Integer kernelSizeX,
+                                                  Integer kernelSizeY)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "maximum_slicewise_image3d",
+                        parameters);
+  }
+
+  public static boolean maximumBox(CLKernelExecutor clke,
+                                   ClearCLImage src,
+                                   ClearCLImage dst,
+                                   int radiusX,
+                                   int radiusY,
+                                   int radiusZ)
+  {
+    return executeSeparableKernel(clke,
+                                  src,
+                                  dst,
+                                  "filtering.cl",
+                                  "max_sep_image" + src.getDimension()
+                                                  + "d",
+                                  radiusToKernelSize(radiusX),
+                                  radiusToKernelSize(radiusY),
+                                  radiusToKernelSize(radiusZ),
+                                  radiusX,
+                                  radiusY,
+                                  radiusZ,
+                                  src.getDimension());
+  }
+
+  public static boolean maximumBox(CLKernelExecutor clke,
+                                   ClearCLBuffer src,
+                                   ClearCLBuffer dst,
+                                   int radiusX,
+                                   int radiusY,
+                                   int radiusZ)
+  {
+    return executeSeparableKernel(clke,
+                                  src,
+                                  dst,
+                                  "filtering.cl",
+                                  "max_sep_image" + src.getDimension()
+                                                  + "d",
+                                  radiusToKernelSize(radiusX),
+                                  radiusToKernelSize(radiusY),
+                                  radiusToKernelSize(radiusZ),
+                                  radiusX,
+                                  radiusY,
+                                  radiusZ,
+                                  src.getDimension());
+  }
+
+  public static boolean maximumSliceBySliceSphere(CLKernelExecutor clke,
+                                                  ClearCLBuffer src,
+                                                  ClearCLBuffer dst,
+                                                  Integer kernelSizeX,
+                                                  Integer kernelSizeY)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "maximum_slicewise_image3d",
+                        parameters);
+  }
+
+  public static boolean maximumImages(CLKernelExecutor clke,
+                                      ClearCLImage src,
+                                      ClearCLImage src1,
+                                      ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("src1", src1);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(),
+                         src1.getDimension(),
+                         dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (maximumImages)");
+    }
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "maxPixelwise_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean maximumImages(CLKernelExecutor clke,
+                                      ClearCLBuffer src,
+                                      ClearCLBuffer src1,
+                                      ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("src1", src1);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(),
+                         src1.getDimension(),
+                         dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (maximumImages)");
+    }
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "maxPixelwise_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean maximumImageAndScalar(CLKernelExecutor clke,
+                                              ClearCLImage src,
+                                              ClearCLImage dst,
+                                              Float valueB)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("valueB", valueB);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(),
+                         src.getDimension(),
+                         dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (maximumImages)");
+    }
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "maxPixelwiseScalar_" + src.getDimension()
+                                   + "d",
+                        parameters);
+  }
+
+  public static boolean maximumImageAndScalar(CLKernelExecutor clke,
+                                              ClearCLBuffer src,
+                                              ClearCLBuffer dst,
+                                              Float valueB)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("valueB", valueB);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(),
+                         src.getDimension(),
+                         dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (maximumImages)");
+    }
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "maxPixelwiseScalar_" + src.getDimension()
+                                   + "d",
+                        parameters);
+  }
+
+  public static boolean minimumImages(CLKernelExecutor clke,
+                                      ClearCLImage src,
+                                      ClearCLImage src1,
+                                      ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("src1", src1);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(),
+                         src1.getDimension(),
+                         dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (minimumImages)");
+    }
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "minPixelwise_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean minimumImages(CLKernelExecutor clke,
+                                      ClearCLBuffer src,
+                                      ClearCLBuffer src1,
+                                      ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("src1", src1);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(),
+                         src1.getDimension(),
+                         dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (minimumImages)");
+    }
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "minPixelwise_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean minimumImageAndScalar(CLKernelExecutor clke,
+                                              ClearCLImage src,
+                                              ClearCLImage dst,
+                                              Float valueB)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("valueB", valueB);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(),
+                         src.getDimension(),
+                         dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (minimumImageAndScalar)");
+    }
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "minPixelwiseScalar_" + src.getDimension()
+                                   + "d",
+                        parameters);
+  }
+
+  public static boolean minimumImageAndScalar(CLKernelExecutor clke,
+                                              ClearCLBuffer src,
+                                              ClearCLBuffer dst,
+                                              Float valueB)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("valueB", valueB);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(),
+                         src.getDimension(),
+                         dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (minimumImageAndScalar)");
+    }
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "minPixelwiseScalar_" + src.getDimension()
+                                   + "d",
+                        parameters);
+  }
+
+  public static boolean maximumZProjection(CLKernelExecutor clke,
+                                           ClearCLImage src,
+                                           ClearCLImage dst_max)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst_max", dst_max);
+
+    clke.execute(Kernels.class,
+                 "projections.cl",
+                 "max_project_3d_2d",
+                 parameters);
+
+    return true;
+  }
+
+  public static boolean maximumZProjection(CLKernelExecutor clke,
+                                           ClearCLBuffer src,
+                                           ClearCLBuffer dst_max)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst_max", dst_max);
+
+    clke.execute(Kernels.class,
+                 "projections.cl",
+                 "max_project_3d_2d",
+                 parameters);
+
+    return true;
+  }
+
+  public static boolean minimumZProjection(CLKernelExecutor clke,
+                                           ClearCLImage src,
+                                           ClearCLImage dst_min)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst_min", dst_min);
+
+    clke.execute(Kernels.class,
+                 "projections.cl",
+                 "min_project_3d_2d",
+                 parameters);
+
+    return true;
+  }
+
+  public static boolean minimumZProjection(CLKernelExecutor clke,
+                                           ClearCLBuffer src,
+                                           ClearCLBuffer dst_min)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst_min", dst_min);
+
+    clke.execute(Kernels.class,
+                 "projections.cl",
+                 "min_project_3d_2d",
+                 parameters);
+
+    return true;
+  }
+
+  public static boolean meanZProjection(CLKernelExecutor clke,
+                                        ClearCLImage src,
+                                        ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+
+    clke.execute(Kernels.class,
+                 "projections.cl",
+                 "mean_project_3d_2d",
+                 parameters);
+
+    return true;
+  }
+
+  public static boolean meanZProjection(CLKernelExecutor clke,
+                                        ClearCLBuffer src,
+                                        ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+
+    clke.execute(Kernels.class,
+                 "projections.cl",
+                 "mean_project_3d_2d",
+                 parameters);
+
+    return true;
+  }
+
+  public static boolean maximumXYZProjection(CLKernelExecutor clke,
+                                             ClearCLImage src,
+                                             ClearCLImage dst_max,
+                                             Integer projectedDimensionX,
+                                             Integer projectedDimensionY,
+                                             Integer projectedDimension)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst_max", dst_max);
+    parameters.put("projection_x", projectedDimensionX);
+    parameters.put("projection_y", projectedDimensionY);
+    parameters.put("projection_dim", projectedDimension);
+
+    clke.execute(Kernels.class,
+                 "projections.cl",
+                 "max_project_dim_select_3d_2d",
+                 parameters);
+
+    return true;
+  }
+
+  public static boolean maximumXYZProjection(CLKernelExecutor clke,
+                                             ClearCLBuffer src,
+                                             ClearCLBuffer dst_max,
+                                             Integer projectedDimensionX,
+                                             Integer projectedDimensionY,
+                                             Integer projectedDimension)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst_max", dst_max);
+    parameters.put("projection_x", projectedDimensionX);
+    parameters.put("projection_y", projectedDimensionY);
+    parameters.put("projection_dim", projectedDimension);
+
+    clke.execute(Kernels.class,
+                 "projections.cl",
+                 "max_project_dim_select_3d_2d",
+                 parameters);
+
+    return true;
+  }
+
+  public static boolean meanSphere(CLKernelExecutor clke,
+                                   ClearCLImage src,
+                                   ClearCLImage dst,
+                                   Integer kernelSizeX,
+                                   Integer kernelSizeY)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "mean_image2d",
+                        parameters);
+  }
+
+  public static boolean meanSphere(CLKernelExecutor clke,
+                                   ClearCLBuffer src,
+                                   ClearCLBuffer dst,
+                                   Integer kernelSizeX,
+                                   Integer kernelSizeY)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "mean_image2d",
+                        parameters);
+  }
+
+  @Deprecated
+  public static boolean meanIJ(CLKernelExecutor clke,
+                               ClearCLImage src,
+                               ClearCLImage dst,
+                               Integer radius)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("radius", radius);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "mean_image2d_ij",
+                        parameters);
+  }
+
+  @Deprecated
+  public static boolean meanIJ(CLKernelExecutor clke,
+                               ClearCLBuffer src,
+                               ClearCLBuffer dst,
+                               Integer radius)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("radius", radius);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "mean_image2d_ij",
+                        parameters);
+  }
+
+  public static boolean meanSphere(CLKernelExecutor clke,
+                                   ClearCLImage src,
+                                   ClearCLImage dst,
+                                   Integer kernelSizeX,
+                                   Integer kernelSizeY,
+                                   Integer kernelSizeZ)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+    parameters.put("Nz", kernelSizeZ);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "mean_image3d",
+                        parameters);
+  }
+
+  public static boolean meanSphere(CLKernelExecutor clke,
+                                   ClearCLBuffer src,
+                                   ClearCLBuffer dst,
+                                   Integer kernelSizeX,
+                                   Integer kernelSizeY,
+                                   Integer kernelSizeZ)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+    parameters.put("Nz", kernelSizeZ);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "mean_image3d",
+                        parameters);
+  }
+
+  public static boolean meanBox(CLKernelExecutor clke,
+                                ClearCLImage src,
+                                ClearCLImage dst,
+                                int radiusX,
+                                int radiusY,
+                                int radiusZ)
+  {
+    return executeSeparableKernel(clke,
+                                  src,
+                                  dst,
+                                  "filtering.cl",
+                                  "mean_sep_image" + src.getDimension()
+                                                  + "d",
+                                  radiusToKernelSize(radiusX),
+                                  radiusToKernelSize(radiusY),
+                                  radiusToKernelSize(radiusZ),
+                                  radiusX,
+                                  radiusY,
+                                  radiusZ,
+                                  src.getDimension());
+  }
+
+  public static boolean meanBox(CLKernelExecutor clke,
+                                ClearCLBuffer src,
+                                ClearCLBuffer dst,
+                                int radiusX,
+                                int radiusY,
+                                int radiusZ)
+  {
+    return executeSeparableKernel(clke,
+                                  src,
+                                  dst,
+                                  "filtering.cl",
+                                  "mean_sep_image" + src.getDimension()
+                                                  + "d",
+                                  radiusToKernelSize(radiusX),
+                                  radiusToKernelSize(radiusY),
+                                  radiusToKernelSize(radiusZ),
+                                  radiusX,
+                                  radiusY,
+                                  radiusZ,
+                                  src.getDimension());
+  }
+
+  public static boolean meanSliceBySliceSphere(CLKernelExecutor clke,
+                                               ClearCLImage src,
+                                               ClearCLImage dst,
+                                               Integer kernelSizeX,
+                                               Integer kernelSizeY)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "mean_slicewise_image3d",
+                        parameters);
+  }
+
+  public static boolean meanSliceBySliceSphere(CLKernelExecutor clke,
+                                               ClearCLBuffer src,
+                                               ClearCLBuffer dst,
+                                               Integer kernelSizeX,
+                                               Integer kernelSizeY)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "mean_slicewise_image3d",
+                        parameters);
+  }
+
+  public static boolean medianSphere(CLKernelExecutor clke,
+                                     ClearCLImage src,
+                                     ClearCLImage dst,
+                                     Integer kernelSizeX,
+                                     Integer kernelSizeY)
+  {
+    if (kernelSizeX * kernelSizeY > CLKernelExecutor.MAX_ARRAY_SIZE)
+    {
+      throw new IllegalArgumentException("Error: kernels of the medianSphere filter is too big. Consider increasing MAX_ARRAY_SIZE.");
+    }
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "median_image2d",
+                        parameters);
+  }
+
+  public static boolean medianSphere(CLKernelExecutor clke,
+                                     ClearCLBuffer src,
+                                     ClearCLBuffer dst,
+                                     Integer kernelSizeX,
+                                     Integer kernelSizeY)
+  {
+    if (kernelSizeX * kernelSizeY > CLKernelExecutor.MAX_ARRAY_SIZE)
+    {
+      throw new IllegalArgumentException("Error: kernels of the medianSphere filter is too big. Consider increasing MAX_ARRAY_SIZE.");
+    }
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "median_image2d",
+                        parameters);
+  }
+
+  public static boolean medianSphere(CLKernelExecutor clke,
+                                     ClearCLImage src,
+                                     ClearCLImage dst,
+                                     Integer kernelSizeX,
+                                     Integer kernelSizeY,
+                                     Integer kernelSizeZ)
+  {
+    if (kernelSizeX * kernelSizeY
+        * kernelSizeZ > CLKernelExecutor.MAX_ARRAY_SIZE)
+    {
+      throw new IllegalArgumentException("Error: kernels of the medianSphere filter is too big. Consider increasing MAX_ARRAY_SIZE.");
+    }
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+    parameters.put("Nz", kernelSizeZ);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "median_image3d",
+                        parameters);
+  }
+
+  public static boolean medianSphere(CLKernelExecutor clke,
+                                     ClearCLBuffer src,
+                                     ClearCLBuffer dst,
+                                     Integer kernelSizeX,
+                                     Integer kernelSizeY,
+                                     Integer kernelSizeZ)
+  {
+    if (kernelSizeX * kernelSizeY
+        * kernelSizeZ > CLKernelExecutor.MAX_ARRAY_SIZE)
+    {
+      throw new IllegalArgumentException("Error: kernels of the medianSphere filter is too big. Consider increasing MAX_ARRAY_SIZE.");
+    }
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+    parameters.put("Nz", kernelSizeZ);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "median_image3d",
+                        parameters);
+  }
+
+  public static boolean medianSliceBySliceSphere(CLKernelExecutor clke,
+                                                 ClearCLImage src,
+                                                 ClearCLImage dst,
+                                                 Integer kernelSizeX,
+                                                 Integer kernelSizeY)
+  {
+    if (kernelSizeX * kernelSizeY > CLKernelExecutor.MAX_ARRAY_SIZE)
+    {
+      throw new IllegalArgumentException("Error: kernels of the medianSphere filter is too big. Consider increasing MAX_ARRAY_SIZE.");
+    }
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "median_slicewise_image3d",
+                        parameters);
+  }
+
+  public static boolean medianSliceBySliceSphere(CLKernelExecutor clke,
+                                                 ClearCLBuffer src,
+                                                 ClearCLBuffer dst,
+                                                 Integer kernelSizeX,
+                                                 Integer kernelSizeY)
+  {
+    if (kernelSizeX * kernelSizeY > CLKernelExecutor.MAX_ARRAY_SIZE)
+    {
+      throw new IllegalArgumentException("Error: kernels of the medianSphere filter is too big. Consider increasing MAX_ARRAY_SIZE.");
+    }
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "median_slicewise_image3d",
+                        parameters);
+  }
+
+  public static boolean medianBox(CLKernelExecutor clke,
+                                  ClearCLImage src,
+                                  ClearCLImage dst,
+                                  Integer kernelSizeX,
+                                  Integer kernelSizeY)
+  {
+    if (kernelSizeX * kernelSizeY > CLKernelExecutor.MAX_ARRAY_SIZE)
+    {
+      throw new IllegalArgumentException("Error: kernels of the medianSphere filter is too big. Consider increasing MAX_ARRAY_SIZE.");
+    }
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "median_box_image2d",
+                        parameters);
+  }
+
+  public static boolean medianBox(CLKernelExecutor clke,
+                                  ClearCLBuffer src,
+                                  ClearCLBuffer dst,
+                                  Integer kernelSizeX,
+                                  Integer kernelSizeY)
+  {
+    if (kernelSizeX * kernelSizeY > CLKernelExecutor.MAX_ARRAY_SIZE)
+    {
+      throw new IllegalArgumentException("Error: kernels of the medianSphere filter is too big. Consider increasing MAX_ARRAY_SIZE.");
+    }
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "median_box_image2d",
+                        parameters);
+  }
+
+  public static boolean medianBox(CLKernelExecutor clke,
+                                  ClearCLImage src,
+                                  ClearCLImage dst,
+                                  Integer kernelSizeX,
+                                  Integer kernelSizeY,
+                                  Integer kernelSizeZ)
+  {
+    if (kernelSizeX * kernelSizeY
+        * kernelSizeZ > CLKernelExecutor.MAX_ARRAY_SIZE)
+    {
+      throw new IllegalArgumentException("Error: kernels of the medianSphere filter is too big. Consider increasing MAX_ARRAY_SIZE.");
+    }
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+    parameters.put("Nz", kernelSizeZ);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "median_box_image3d",
+                        parameters);
+  }
+
+  public static boolean medianBox(CLKernelExecutor clke,
+                                  ClearCLBuffer src,
+                                  ClearCLBuffer dst,
+                                  Integer kernelSizeX,
+                                  Integer kernelSizeY,
+                                  Integer kernelSizeZ)
+  {
+    if (kernelSizeX * kernelSizeY
+        * kernelSizeZ > CLKernelExecutor.MAX_ARRAY_SIZE)
+    {
+      throw new IllegalArgumentException("Error: kernels of the medianSphere filter is too big. Consider increasing MAX_ARRAY_SIZE.");
+    }
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+    parameters.put("Nz", kernelSizeZ);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "median_box_image3d",
+                        parameters);
+  }
+
+  public static boolean medianSliceBySliceBox(CLKernelExecutor clke,
+                                              ClearCLImage src,
+                                              ClearCLImage dst,
+                                              Integer kernelSizeX,
+                                              Integer kernelSizeY)
+  {
+    if (kernelSizeX * kernelSizeY > CLKernelExecutor.MAX_ARRAY_SIZE)
+    {
+      throw new IllegalArgumentException("Error: kernels of the medianSphere filter is too big. Consider increasing MAX_ARRAY_SIZE.");
+    }
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "median_box_slicewise_image3d",
+                        parameters);
+  }
+
+  public static boolean medianSliceBySliceBox(CLKernelExecutor clke,
+                                              ClearCLBuffer src,
+                                              ClearCLBuffer dst,
+                                              Integer kernelSizeX,
+                                              Integer kernelSizeY)
+  {
+    if (kernelSizeX * kernelSizeY > CLKernelExecutor.MAX_ARRAY_SIZE)
+    {
+      throw new IllegalArgumentException("Error: kernels of the medianSphere filter is too big. Consider increasing MAX_ARRAY_SIZE.");
+    }
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "median_box_slicewise_image3d",
+                        parameters);
+  }
+
+  public static boolean minimumSphere(CLKernelExecutor clke,
+                                      ClearCLImage src,
+                                      ClearCLImage dst,
+                                      Integer kernelSizeX,
+                                      Integer kernelSizeY)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "minimum_image2d",
+                        parameters);
+  }
+
+  public static boolean minimumSphere(CLKernelExecutor clke,
+                                      ClearCLBuffer src,
+                                      ClearCLBuffer dst,
+                                      Integer kernelSizeX,
+                                      Integer kernelSizeY)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "minimum_image2d",
+                        parameters);
+  }
+
+  public static boolean minimumSphere(CLKernelExecutor clke,
+                                      ClearCLImage src,
+                                      ClearCLImage dst,
+                                      Integer kernelSizeX,
+                                      Integer kernelSizeY,
+                                      Integer kernelSizeZ)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+    parameters.put("Nz", kernelSizeZ);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "minimum_image3d",
+                        parameters);
+  }
+
+  public static boolean minimumSphere(CLKernelExecutor clke,
+                                      ClearCLBuffer src,
+                                      ClearCLBuffer dst,
+                                      Integer kernelSizeX,
+                                      Integer kernelSizeY,
+                                      Integer kernelSizeZ)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+    parameters.put("Nz", kernelSizeZ);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "minimum_image3d",
+                        parameters);
+  }
+
+  @Deprecated
+  public static boolean minimumIJ(CLKernelExecutor clke,
+                                  ClearCLImage src,
+                                  ClearCLImage dst,
+                                  Integer radius)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("radius", radius);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "minimum_image2d_ij",
+                        parameters);
+  }
+
+  @Deprecated
+  public static boolean minimumIJ(CLKernelExecutor clke,
+                                  ClearCLBuffer src,
+                                  ClearCLBuffer dst,
+                                  Integer radius)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("radius", radius);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "minimum_image2d_ij",
+                        parameters);
+  }
+
+  public static boolean minimumBox(CLKernelExecutor clke,
+                                   ClearCLImage src,
+                                   ClearCLImage dst,
+                                   int radiusX,
+                                   int radiusY,
+                                   int radiusZ)
+  {
+    return executeSeparableKernel(clke,
+                                  src,
+                                  dst,
+                                  "filtering.cl",
+                                  "min_sep_image" + src.getDimension()
+                                                  + "d",
+                                  radiusToKernelSize(radiusX),
+                                  radiusToKernelSize(radiusY),
+                                  radiusToKernelSize(radiusZ),
+                                  radiusX,
+                                  radiusY,
+                                  radiusZ,
+                                  src.getDimension());
+  }
+
+  public static boolean minimumBox(CLKernelExecutor clke,
+                                   ClearCLBuffer src,
+                                   ClearCLBuffer dst,
+                                   int radiusX,
+                                   int radiusY,
+                                   int radiusZ)
+  {
+    return executeSeparableKernel(clke,
+                                  src,
+                                  dst,
+                                  "filtering.cl",
+                                  "min_sep_image" + src.getDimension()
+                                                  + "d",
+                                  radiusToKernelSize(radiusX),
+                                  radiusToKernelSize(radiusY),
+                                  radiusToKernelSize(radiusZ),
+                                  radiusX,
+                                  radiusY,
+                                  radiusZ,
+                                  src.getDimension());
+  }
+
+  public static boolean minimumSliceBySliceSphere(CLKernelExecutor clke,
+                                                  ClearCLImage src,
+                                                  ClearCLImage dst,
+                                                  Integer kernelSizeX,
+                                                  Integer kernelSizeY)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "minimum_slicewise_image3d",
+                        parameters);
+  }
+
+  public static boolean minimumSliceBySliceSphere(CLKernelExecutor clke,
+                                                  ClearCLBuffer src,
+                                                  ClearCLBuffer dst,
+                                                  Integer kernelSizeX,
+                                                  Integer kernelSizeY)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("Nx", kernelSizeX);
+    parameters.put("Ny", kernelSizeY);
+
+    return clke.execute(Kernels.class,
+                        "filtering.cl",
+                        "minimum_slicewise_image3d",
+                        parameters);
+  }
+
+  public static boolean multiplyImages(CLKernelExecutor clke,
+                                       ClearCLImage src,
+                                       ClearCLImage src1,
+                                       ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("src1", src1);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(),
+                         src1.getDimension(),
+                         dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (addImageAndScalar)");
+    }
+
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "multiplyPixelwise_" + src.getDimension()
+                                   + "d",
+                        parameters);
+  }
+
+  public static boolean multiplyImages(CLKernelExecutor clke,
+                                       ClearCLBuffer src,
+                                       ClearCLBuffer src1,
+                                       ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("src1", src1);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(),
+                         src1.getDimension(),
+                         dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (addImageAndScalar)");
+    }
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "multiplyPixelwise_" + src.getDimension()
+                                   + "d",
+                        parameters);
+  }
+
+  public static boolean multiplyImageAndCoordinate(CLKernelExecutor clke,
+                                                   ClearCLImage src,
+                                                   ClearCLImage dst,
+                                                   Integer dimension)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dimension", dimension);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (multiplyImageAndCoordinate)");
+    }
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "multiply_pixelwise_with_coordinate_3d",
+                        parameters);
+  }
+
+  public static boolean multiplyImageAndCoordinate(CLKernelExecutor clke,
+                                                   ClearCLBuffer src,
+                                                   ClearCLBuffer dst,
+                                                   Integer dimension)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dimension", dimension);
+    parameters.put("dst", dst);
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (multiplyImageAndCoordinate)");
+    }
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "multiply_pixelwise_with_coordinate_3d",
+                        parameters);
+  }
+
+  public static boolean multiplyImageAndScalar(CLKernelExecutor clke,
+                                               ClearCLImage src,
+                                               ClearCLImage dst,
+                                               Float scalar)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("scalar", scalar);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (addImageAndScalar)");
+    }
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "multiplyScalar_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean multiplyImageAndScalar(CLKernelExecutor clke,
+                                               ClearCLBuffer src,
+                                               ClearCLBuffer dst,
+                                               Float scalar)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("scalar", scalar);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (addImageAndScalar)");
+    }
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "multiplyScalar_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean multiplySliceBySliceWithScalars(CLKernelExecutor clke,
+                                                        ClearCLImage src,
+                                                        ClearCLImage dst,
+                                                        float[] scalars)
+  {
+    if (dst.getDimensions()[2] != scalars.length)
+    {
+      throw new IllegalArgumentException("Error: Wrong number of scalars in array.");
+    }
+
+    FloatBuffer buffer = FloatBuffer.allocate(scalars.length);
+    buffer.put(scalars);
+
+    ClearCLBuffer clBuffer = clke.createCLBuffer(new long[]
+    { scalars.length }, NativeTypeEnum.Float);
+    clBuffer.readFrom(buffer, true);
+    buffer.clear();
+
+    HashMap<String, Object> map = new HashMap<String, Object>();
+    map.put("src", src);
+    map.put("scalars", clBuffer);
+    map.put("dst", dst);
+    boolean result = clke.execute(Kernels.class,
+                                  "math.cl",
+                                  "multiplySliceBySliceWithScalars",
+                                  map);
+
+    clBuffer.close();
+
+    return result;
+  }
+
+  public static boolean multiplySliceBySliceWithScalars(CLKernelExecutor clke,
+                                                        ClearCLBuffer src,
+                                                        ClearCLBuffer dst,
+                                                        float[] scalars)
+  {
+    if (dst.getDimensions()[2] != scalars.length)
+    {
+      throw new IllegalArgumentException("Error: Wrong number of scalars in array.");
+    }
+
+    FloatBuffer buffer = FloatBuffer.allocate(scalars.length);
+    buffer.put(scalars);
+
+    ClearCLBuffer clBuffer = clke.createCLBuffer(new long[]
+    { scalars.length }, NativeTypeEnum.Float);
+    clBuffer.readFrom(buffer, true);
+    buffer.clear();
+
+    HashMap<String, Object> map = new HashMap<String, Object>();
+    map.put("src", src);
+    map.put("scalars", clBuffer);
+    map.put("dst", dst);
+    boolean result = clke.execute(Kernels.class,
+                                  "math.cl",
+                                  "multiplySliceBySliceWithScalars",
+                                  map);
+
+    clBuffer.close();
+
+    return result;
+  }
+
+  public static boolean multiplyStackWithPlane(CLKernelExecutor clke,
+                                               ClearCLImage input3d,
+                                               ClearCLImage input2d,
+                                               ClearCLImage output3d)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", input3d);
+    parameters.put("src1", input2d);
+    parameters.put("dst", output3d);
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "multiplyStackWithPlanePixelwise",
+                        parameters);
+  }
+
+  public static boolean multiplyStackWithPlane(CLKernelExecutor clke,
+                                               ClearCLBuffer input3d,
+                                               ClearCLBuffer input2d,
+                                               ClearCLBuffer output3d)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", input3d);
+    parameters.put("src1", input2d);
+    parameters.put("dst", output3d);
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "multiplyStackWithPlanePixelwise",
+                        parameters);
+  }
+
+  public static boolean power(CLKernelExecutor clke,
+                              ClearCLImage src,
+                              ClearCLImage dst,
+                              Float exponent)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("exponent", exponent);
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "power_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean power(CLKernelExecutor clke,
+                              ClearCLBuffer src,
+                              ClearCLBuffer dst,
+                              Float exponent)
+  {
+
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("exponent", exponent);
+
+    return clke.execute(Kernels.class,
+                        "math.cl",
+                        "power_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean radialProjection(CLKernelExecutor clke,
+                                         ClearCLImage src,
+                                         ClearCLImage dst,
+                                         Float deltaAngle)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+
+    parameters.clear();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("deltaAngle", deltaAngle);
+
+    return clke.execute(Kernels.class,
+                        "projections.cl",
+                        "radialProjection3d",
+                        parameters);
+  }
+
+  public static boolean radialProjection(CLKernelExecutor clke,
+                                         ClearCLBuffer src,
+                                         ClearCLBuffer dst,
+                                         Float deltaAngle)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+
+    parameters.clear();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+    parameters.put("deltaAngle", deltaAngle);
+
+    return clke.execute(Kernels.class,
+                        "projections.cl",
+                        "radialProjection3d",
+                        parameters);
+  }
+
+  public static boolean resliceBottom(CLKernelExecutor clke,
+                                      ClearCLImage src,
+                                      ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+
+    parameters.clear();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+
+    return clke.execute(Kernels.class,
+                        "reslicing.cl",
+                        "reslice_bottom_3d",
+                        parameters);
+  }
+
+  public static boolean resliceBottom(CLKernelExecutor clke,
+                                      ClearCLBuffer src,
+                                      ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+
+    parameters.clear();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+
+    return clke.execute(Kernels.class,
+                        "reslicing.cl",
+                        "reslice_bottom_3d",
+                        parameters);
+  }
+
+  public static boolean resliceLeft(CLKernelExecutor clke,
+                                    ClearCLImage src,
+                                    ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+
+    return clke.execute(Kernels.class,
+                        "reslicing.cl",
+                        "reslice_left_3d",
+                        parameters);
+  }
+
+  public static boolean resliceLeft(CLKernelExecutor clke,
+                                    ClearCLBuffer src,
+                                    ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+
+    return clke.execute(Kernels.class,
+                        "reslicing.cl",
+                        "reslice_left_3d",
+                        parameters);
+  }
+
+  public static boolean resliceRight(CLKernelExecutor clke,
+                                     ClearCLImage src,
+                                     ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+
+    return clke.execute(Kernels.class,
+                        "reslicing.cl",
+                        "reslice_right_3d",
+                        parameters);
+  }
+
+  public static boolean resliceRight(CLKernelExecutor clke,
+                                     ClearCLBuffer src,
+                                     ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+
+    return clke.execute(Kernels.class,
+                        "reslicing.cl",
+                        "reslice_right_3d",
+                        parameters);
+  }
+
+  public static boolean resliceTop(CLKernelExecutor clke,
+                                   ClearCLImage src,
+                                   ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+
+    return clke.execute(Kernels.class,
+                        "reslicing.cl",
+                        "reslice_top_3d",
+                        parameters);
+  }
+
+  public static boolean resliceTop(CLKernelExecutor clke,
+                                   ClearCLBuffer src,
+                                   ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+
+    return clke.execute(Kernels.class,
+                        "reslicing.cl",
+                        "reslice_top_3d",
+                        parameters);
+  }
+
+  public static boolean rotateLeft(CLKernelExecutor clke,
+                                   ClearCLBuffer src,
+                                   ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+
+    return clke.execute(Kernels.class,
+                        "rotate.cl",
+                        "rotate_left_" + dst.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean rotateLeft(CLKernelExecutor clke,
+                                   ClearCLImage src,
+                                   ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+
+    return clke.execute(Kernels.class,
+                        "rotate.cl",
+                        "rotate_left_" + dst.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean rotateRight(CLKernelExecutor clke,
+                                    ClearCLBuffer src,
+                                    ClearCLBuffer dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+
+    return clke.execute(Kernels.class,
+                        "rotate.cl",
+                        "rotate_right_" + dst.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean rotateRight(CLKernelExecutor clke,
+                                    ClearCLImage src,
+                                    ClearCLImage dst)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+
+    return clke.execute(Kernels.class,
+                        "rotate.cl",
+                        "rotate_right_" + dst.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean set(CLKernelExecutor clke,
+                            ClearCLImage clImage,
+                            Float value)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("dst", clImage);
+    parameters.put("value", value);
+
+    return clke.execute(Kernels.class,
+                        "set.cl",
+                        "set_" + clImage.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean set(CLKernelExecutor clke,
+                            ClearCLBuffer clImage,
+                            Float value)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("dst", clImage);
+    parameters.put("value", value);
+
+    return clke.execute(Kernels.class,
+                        "set.cl",
+                        "set_" + clImage.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean splitStack(CLKernelExecutor clke,
+                                   ClearCLImage clImageIn,
+                                   ClearCLImage... clImagesOut)
+  {
+    if (clImagesOut.length > 12)
+    {
+      throw new IllegalArgumentException("Error: splitStack does not support more than 12 stacks.");
+    }
+    if (clImagesOut.length == 1)
+    {
+      return copy(clke, clImageIn, clImagesOut[0]);
+    }
+    if (clImagesOut.length == 0)
+    {
+      throw new IllegalArgumentException("Error: splitstack didn't get any output images.");
+    }
+
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", clImageIn);
+    for (int i = 0; i < clImagesOut.length; i++)
+    {
+      parameters.put("dst" + i, clImagesOut[i]);
+    }
+
+    return clke.execute(Kernels.class,
+                        "stacksplitting.cl",
+                        "split_" + clImagesOut.length + "_stacks",
+                        parameters);
+  }
+
+  public static boolean splitStack(CLKernelExecutor clke,
+                                   ClearCLBuffer clImageIn,
+                                   ClearCLBuffer... clImagesOut)
+  {
+    if (clImagesOut.length > 12)
+    {
+      throw new IllegalArgumentException("Error: splitStack does not support more than 12 stacks.");
+    }
+    if (clImagesOut.length == 1)
+    {
+      return copy(clke, clImageIn, clImagesOut[0]);
+    }
+    if (clImagesOut.length == 0)
+    {
+      throw new IllegalArgumentException("Error: splitstack didn't get any output images.");
+    }
+
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", clImageIn);
+    for (int i = 0; i < clImagesOut.length; i++)
+    {
+      parameters.put("dst" + i, clImagesOut[i]);
+    }
+
+    return clke.execute(Kernels.class,
+                        "stacksplitting.cl",
+                        "split_" + clImagesOut.length + "_stacks",
+                        parameters);
+  }
+
+  public static boolean subtractImages(CLKernelExecutor clke,
+                                       ClearCLImage subtrahend,
+                                       ClearCLImage minuend,
+                                       ClearCLImage destination)
+  {
+    return addImagesWeighted(clke,
+                             subtrahend,
+                             minuend,
+                             destination,
+                             1f,
+                             -1f);
+  }
+
+  public static boolean subtractImages(CLKernelExecutor clke,
+                                       ClearCLBuffer subtrahend,
+                                       ClearCLBuffer minuend,
+                                       ClearCLBuffer destination)
+  {
+    return addImagesWeighted(clke,
+                             subtrahend,
+                             minuend,
+                             destination,
+                             1f,
+                             -1f);
+  }
+
+  /*
+    public static double maximumOfAllPixels(CLKernelExecutor clke, ClearCLImage clImage) {
+        ClearCLImage clReducedImage = clImage;
+        if (clImage.getDimension() == 3) {
+            clReducedImage = clke.createCLImage(new long[]{clImage.getWidth(), clImage.getHeight()}, clImage.getChannelDataType());
+  
+            HashMap<String, Object> parameters = new HashMap<>();
+            parameters.put("src", clImage);
+            parameters.put("dst_max", clReducedImage);
+            clke.execute(Kernels.class, "projections.cl", "max_project_3d_2d", parameters);
+        }
+  
+        RandomAccessibleInterval rai = clke.convert(clReducedImage, RandomAccessibleInterval.class);
+        Cursor cursor = Views.iterable(rai).cursor();
+        float maximumGreyValue = -Float.MAX_VALUE;
+        while (cursor.hasNext()) {
+            float greyValue = ((RealType) cursor.next()).getRealFloat();
+            if (maximumGreyValue < greyValue) {
+                maximumGreyValue = greyValue;
+            }
+        }
+  
+        if (clImage != clReducedImage) {
+            clReducedImage.close();
+        }
+        return maximumGreyValue;
+    }
+  */
+
+  /*
+  public static double maximumOfAllPixels(CLKernelExecutor clke, ClearCLBuffer clImage) {
+      ClearCLBuffer clReducedImage = clImage;
+      if (clImage.getDimension() == 3) {
+          clReducedImage = clke.createCLBuffer(new long[]{clImage.getWidth(), clImage.getHeight()}, clImage.getNativeType());
+  
+          HashMap<String, Object> parameters = new HashMap<>();
+          parameters.put("src", clImage);
+          parameters.put("dst_max", clReducedImage);
+          clke.execute(Kernels.class, "projections.cl", "max_project_3d_2d", parameters);
+      }
+  
+      RandomAccessibleInterval rai = clke.convert(clReducedImage, RandomAccessibleInterval.class);
+      Cursor cursor = Views.iterable(rai).cursor();
+      float maximumGreyValue = -Float.MAX_VALUE;
+      while (cursor.hasNext()) {
+          float greyValue = ((RealType) cursor.next()).getRealFloat();
+          if (maximumGreyValue < greyValue) {
+              maximumGreyValue = greyValue;
+          }
+      }
+  
+      if (clImage != clReducedImage) {
+          clReducedImage.close();
+      }
+      return maximumGreyValue;
+  }
+  
+  
+  public static double minimumOfAllPixels(CLKernelExecutor clke, ClearCLImage clImage) {
+      ClearCLImage clReducedImage = clImage;
+      if (clImage.getDimension() == 3) {
+          clReducedImage = clke.createCLImage(new long[]{clImage.getWidth(), clImage.getHeight()}, clImage.getChannelDataType());
+  
+          HashMap<String, Object> parameters = new HashMap<>();
+          parameters.put("src", clImage);
+          parameters.put("dst_min", clReducedImage);
+          clke.execute(Kernels.class, "projections.cl", "min_project_3d_2d", parameters);
+      }
+  
+      RandomAccessibleInterval rai = clke.convert(clReducedImage, RandomAccessibleInterval.class);
+      Cursor cursor = Views.iterable(rai).cursor();
+      float minimumGreyValue = Float.MAX_VALUE;
+      while (cursor.hasNext()) {
+          float greyValue = ((RealType) cursor.next()).getRealFloat();
+          if (minimumGreyValue > greyValue) {
+              minimumGreyValue = greyValue;
+          }
+      }
+  
+      if (clImage != clReducedImage) {
+          clReducedImage.close();
+      }
+      return minimumGreyValue;
+  }
+  
+  
+  public static double minimumOfAllPixels(CLKernelExecutor clke, ClearCLBuffer clImage) {
+      ClearCLBuffer clReducedImage = clImage;
+      if (clImage.getDimension() == 3) {
+          clReducedImage = clke.createCLBuffer(new long[]{clImage.getWidth(), clImage.getHeight()}, clImage.getNativeType());
+  
+          HashMap<String, Object> parameters = new HashMap<>();
+          parameters.put("src", clImage);
+          parameters.put("dst_min", clReducedImage);
+          clke.execute(Kernels.class, "projections.cl", "min_project_3d_2d", parameters);
+      }
+  
+      RandomAccessibleInterval rai = clke.convert(clReducedImage, RandomAccessibleInterval.class);
+      Cursor cursor = Views.iterable(rai).cursor();
+      float minimumGreyValue = Float.MAX_VALUE;
+      while (cursor.hasNext()) {
+          float greyValue = ((RealType) cursor.next()).getRealFloat();
+          if (minimumGreyValue > greyValue) {
+              minimumGreyValue = greyValue;
+          }
+      }
+  
+      if (clImage != clReducedImage) {
+          clReducedImage.close();
+      }
+      return minimumGreyValue;
+  }
+  
+  public static double sumPixels(CLKernelExecutor clke, ClearCLImage clImage) {
+      ClearCLImage clReducedImage = clImage;
+      if (clImage.getDimension() == 3) {
+          clReducedImage = clke.createCLImage(new long[]{clImage.getWidth(), clImage.getHeight()}, clImage.getChannelDataType());
+  
+          HashMap<String, Object> parameters = new HashMap<>();
+          parameters.put("src", clImage);
+          parameters.put("dst", clReducedImage);
+          clke.execute(Kernels.class, "projections.cl", "sum_project_3d_2d", parameters);
+      }
+  
+      RandomAccessibleInterval rai = clke.convert(clReducedImage, RandomAccessibleInterval.class);
+      Cursor cursor = Views.iterable(rai).cursor();
+      float sum = 0;
+      while (cursor.hasNext()) {
+          sum += ((RealType) cursor.next()).getRealFloat();
+      }
+  
+      if (clImage != clReducedImage) {
+          clReducedImage.close();
+      }
+      return sum;
+  }
+  
+  public static double sumPixels(CLKernelExecutor clke, ClearCLBuffer clImage) {
+      ClearCLBuffer clReducedImage = clImage;
+      if (clImage.getDimension() == 3) {
+          clReducedImage = clke.createCLBuffer(new long[]{clImage.getWidth(), clImage.getHeight()}, clImage.getNativeType());
+  
+          HashMap<String, Object> parameters = new HashMap<>();
+          parameters.put("src", clImage);
+          parameters.put("dst", clReducedImage);
+          clke.execute(Kernels.class, "projections.cl", "sum_project_3d_2d", parameters);
+      }
+  
+      RandomAccessibleInterval rai = clke.convert(clReducedImage, RandomAccessibleInterval.class);
+      Cursor cursor = Views.iterable(rai).cursor();
+      float sum = 0;
+      while (cursor.hasNext()) {
+          sum += ((RealType) cursor.next()).getRealFloat();
+      }
+  
+      if (clImage != clReducedImage) {
+          clReducedImage.close();
+      }
+      return sum;
+  }
+  
+  
+  public static double[] sumPixelsSliceBySlice(CLKernelExecutor clke, ClearCLImage input) {
+      if (input.getDimension() == 2) {
+          return new double[]{sumPixels(clke, input)};
+      }
+  
+      int numberOfImages = (int) input.getDepth();
+      double[] result = new double[numberOfImages];
+  
+      ClearCLImage slice = clke.createCLImage(new long[]{input.getWidth(), input.getHeight()}, input.getChannelDataType());
+      for (int z = 0; z < numberOfImages; z++) {
+          copySlice(clke, input, slice, z);
+          result[z] = sumPixels(clke, slice);
+      }
+      slice.close();
+      return result;
+  }
+  
+  public static double[] sumPixelsSliceBySlice(CLKernelExecutor clke, ClearCLBuffer input) {
+      if (input.getDimension() == 2) {
+          return new double[]{sumPixels(clke, input)};
+      }
+  
+      int numberOfImages = (int) input.getDepth();
+      double[] result = new double[numberOfImages];
+  
+      ClearCLBuffer slice = clke.createCLBuffer(new long[]{input.getWidth(), input.getHeight()}, input.getNativeType());
+      for (int z = 0; z < numberOfImages; z++) {
+          copySlice(clke, input, slice, z);
+          result[z] = sumPixels(clke, slice);
+      }
+      slice.close();
+      return result;
+  }
+  */
+
+  public static boolean sumZProjection(CLKernelExecutor clke,
+                                       ClearCLImage clImage,
+                                       ClearCLImage clReducedImage)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", clImage);
+    parameters.put("dst", clReducedImage);
+    return clke.execute(Kernels.class,
+                        "projections.cl",
+                        "sum_project_3d_2d",
+                        parameters);
+  }
+
+  public static boolean sumZProjection(CLKernelExecutor clke,
+                                       ClearCLBuffer clImage,
+                                       ClearCLBuffer clReducedImage)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", clImage);
+    parameters.put("dst", clReducedImage);
+    return clke.execute(Kernels.class,
+                        "projections.cl",
+                        "sum_project_3d_2d",
+                        parameters);
+  }
+
+  public static boolean tenengradWeightsSliceBySlice(CLKernelExecutor clke,
+                                                     ClearCLImage clImageOut,
+                                                     ClearCLImage clImageIn)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+    parameters.put("src", clImageIn);
+    parameters.put("dst", clImageOut);
+    return clke.execute(Kernels.class,
+                        "tenengradFusion.cl",
+                        "tenengrad_weight_unnormalized_slice_wise",
+                        parameters);
+  }
+
+  public static boolean tenengradFusion(CLKernelExecutor clke,
+                                        ClearCLImage clImageOut,
+                                        float[] blurSigmas,
+                                        ClearCLImage... clImagesIn)
+  {
+    return tenengradFusion(clke,
+                           clImageOut,
+                           blurSigmas,
+                           1.0f,
+                           clImagesIn);
+  }
+
+  public static boolean tenengradFusion(CLKernelExecutor clke,
+                                        ClearCLImage clImageOut,
+                                        float[] blurSigmas,
+                                        float exponent,
+                                        ClearCLImage... clImagesIn)
+  {
+    if (clImagesIn.length > 12)
+    {
+      throw new IllegalArgumentException("Error: tenengradFusion does not support more than 12 stacks.");
+    }
+    if (clImagesIn.length == 1)
+    {
+      return copy(clke, clImagesIn[0], clImageOut);
+    }
+    if (clImagesIn.length == 0)
+    {
+      throw new IllegalArgumentException("Error: tenengradFusion didn't get any output images.");
+    }
+    if (!clImagesIn[0].isFloat())
+    {
+      System.out.println("Warning: tenengradFusion may only work on float images!");
+    }
+
+    HashMap<String, Object> lFusionParameters = new HashMap<>();
+
+    ClearCLImage temporaryImage = clke.createCLImage(clImagesIn[0]);
+    ClearCLImage temporaryImage2 = null;
+    if (Math.abs(exponent - 1.0f) > 0.0001)
+    {
+      temporaryImage2 = clke.createCLImage(clImagesIn[0]);
+    }
+
+    ClearCLImage[] temporaryImages =
+                                   new ClearCLImage[clImagesIn.length];
+    for (int i = 0; i < clImagesIn.length; i++)
+    {
+      HashMap<String, Object> parameters = new HashMap<>();
+      temporaryImages[i] = clke.createCLImage(clImagesIn[i]);
+      parameters.put("src", clImagesIn[i]);
+      parameters.put("dst", temporaryImage);
+
+      clke.execute(Kernels.class,
+                   "tenengradFusion.cl",
+                   "tenengrad_weight_unnormalized",
+                   parameters);
+
+      if (temporaryImage2 != null)
+      {
+        power(clke, temporaryImage, temporaryImage2, exponent);
+        blur(clke,
+             temporaryImage2,
+             temporaryImages[i],
+             blurSigmas[0],
+             blurSigmas[1],
+             blurSigmas[2]);
+      }
+      else
+      {
+        blur(clke,
+             temporaryImage,
+             temporaryImages[i],
+             blurSigmas[0],
+             blurSigmas[1],
+             blurSigmas[2]);
+      }
+
+      lFusionParameters.put("src" + i, clImagesIn[i]);
+      lFusionParameters.put("weight" + i, temporaryImages[i]);
+    }
+
+    lFusionParameters.put("dst", clImageOut);
+    lFusionParameters.put("factor",
+                          (int) (clImagesIn[0].getWidth()
+                                 / temporaryImages[0].getWidth()));
+
+    boolean success = clke.execute(Kernels.class,
+                                   "tenengradFusion.cl",
+                                   String.format("tenengrad_fusion_with_provided_weights_%d_images",
+                                                 clImagesIn.length),
+                                   lFusionParameters);
+
+    temporaryImage.close();
+    for (int i = 0; i < temporaryImages.length; i++)
+    {
+      temporaryImages[i].close();
+    }
+
+    if (temporaryImage2 != null)
+    {
+      temporaryImage2.close();
+    }
+
+    return success;
+  }
+
+  public static boolean threshold(CLKernelExecutor clke,
+                                  ClearCLImage src,
+                                  ClearCLImage dst,
+                                  Float threshold)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+
+    parameters.clear();
+    parameters.put("threshold", threshold);
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (addImageAndScalar)");
+    }
+
+    return clke.execute(Kernels.class,
+                        "thresholding.cl",
+                        "apply_threshold_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  public static boolean threshold(CLKernelExecutor clke,
+                                  ClearCLBuffer src,
+                                  ClearCLBuffer dst,
+                                  Float threshold)
+  {
+    HashMap<String, Object> parameters = new HashMap<>();
+
+    parameters.clear();
+    parameters.put("threshold", threshold);
+    parameters.put("src", src);
+    parameters.put("dst", dst);
+
+    if (!checkDimensions(src.getDimension(), dst.getDimension()))
+    {
+      throw new IllegalArgumentException("Error: number of dimensions don't match! (addImageAndScalar)");
+    }
+
+    return clke.execute(Kernels.class,
+                        "thresholding.cl",
+                        "apply_threshold_" + src.getDimension() + "d",
+                        parameters);
+  }
+
+  private static boolean checkDimensions(long... numberOfDimensions)
+  {
+    for (int i = 0; i < numberOfDimensions.length - 1; i++)
+    {
+      if (!(numberOfDimensions[i] == numberOfDimensions[i + 1]))
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+
+}


### PR DESCRIPTION
This PR copies all kernels from CliJ into clearcl.ocllibs.kernels.  That may be a bit harsh.  It seems that the thought was to split these out a bit more.  Happy to re-organize, but we may want to discuss first.

Code modeled on and copied from CliJ to use these kernels is in clearcl.ops.kernels.  Basically, a single instance of CLKernelExecutor will let the user run most (all?) of the kernels in clearcl.ocllibs.kernels by calling static functions in clearcl.ops.kernels.Kernels.  I have not tested it yet, and there may be runtime issues, but I expect it to work.

This approach seems quite different from the approach so far used in clearcl, where an instance of a class is needed for each kernel to be used.  I kind of like Robert's approach, it makes it straight forward to use, and - after instantiating a CLKernelExecutor - all functionality is available without needing to instantiate new classes.  

However, I can not oversee the full design of ClearCL, and am very happy to entertain other approaches, just show me the direction you want to take.

The PR adds utility (static) functions to convert from Direct Buffers to ClearCL and vice versa (now in clearcl.converters).  These do not bring in any new dependencies, and such code is needed fro anyone going from direct buffers into ClearCL, so seems to make sense to have it somewhere.

Unrelated to this PR.  I noted that clearcl.io.TiffWriter brings in dependencies on loci.common and loci.formats.  Seems a bit of a pity, and it would make sense to me to have this code live in another place. 
